### PR TITLE
Flixible souce file

### DIFF
--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Literal, Optional, Union, Callable
+from typing import Literal, Optional, Union, Callable, Any
 
 from cloudpathlib import AnyPath
 import intake
@@ -83,7 +83,7 @@ class SourceFile(SourceBase):
         default="open_dataset",
         description="Model type discriminator",
     )
-    uri: str | Path = Field(description="Path to the dataset")
+    uri: str | Path | list | Any = Field(description="Path to the dataset")
     reader: Optional[Union[str, Callable]] = Field(
         default="xarray.open_dataset",
         validate_default=True,

--- a/rompy/utils.py
+++ b/rompy/utils.py
@@ -33,6 +33,10 @@ def import_function(func_str: str | object) -> object:
         The function imported from func_str
 
     """
+    if not isinstance(func_str, str):
+        logger.debug(f"func_str {func_str} is not a str, returning as is")
+        return func_str
+
     module_name = ".".join(func_str.split(".")[:-1])
     func_name = func_str.split(".")[-1]
     try:

--- a/rompy/utils.py
+++ b/rompy/utils.py
@@ -8,6 +8,7 @@
 
 import logging
 from datetime import datetime
+from importlib import import_module
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,33 @@ import xarray as xr
 from scipy.spatial import KDTree
 
 logger = logging.getLogger("rompy.util")
+
+
+def import_function(func_str: str | object) -> object:
+    """Import function defined from string.
+
+    Parameters
+    ----------
+    func_str: str | object
+        The absolute import path of the function to import if a string, e.g.,
+        'xarray.open_dataset', if an object the same object is returned.
+
+    Returns
+    -------
+    func: object
+        The function imported from func_str
+
+    """
+    module_name = ".".join(func_str.split(".")[:-1])
+    func_name = func_str.split(".")[-1]
+    try:
+        module = import_module(module_name)
+    except ValueError:
+        if module_name == "":
+            raise ValueError(
+                "The full module.func name must be provided rather than only the func"
+            )
+    return getattr(module, func_name)
 
 
 def dict_product(d):

--- a/rompy/utils.py
+++ b/rompy/utils.py
@@ -9,6 +9,7 @@
 import logging
 from datetime import datetime
 from importlib import import_module
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -18,14 +19,15 @@ from scipy.spatial import KDTree
 logger = logging.getLogger("rompy.util")
 
 
-def import_function(func_str: str | object) -> object:
+def import_function(func_str: str | Callable) -> Callable:
     """Import function defined from string.
 
     Parameters
     ----------
-    func_str: str | object
+    func_str: str | Callable
         The absolute import path of the function to import if a string, e.g.,
-        'xarray.open_dataset', if an object the same object is returned.
+        'xarray.open_dataset', or the function callable itself in which case the
+        callable object is returned.
 
     Returns
     -------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -140,7 +140,7 @@ def test_source_file():
 
 def test_source_file_open_mfdataset():
     source = SourceFile(
-        uri=HERE / "data" / "aus-20230101.nc",
+        uri=[HERE / "data" / "aus-20230101.nc"],
         reader="xarray.open_mfdataset",
         kwargs={"chunks": {"time": 2}},
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from rompy.utils import import_function
+
+
+def test_import_function():
+    from xarray import open_dataset
+    func = import_function("xarray.open_dataset")
+    assert open_dataset == func
+
+
+def test_import_function_already_imported():
+    from xarray import open_dataset
+    func = import_function(open_dataset)
+    assert open_dataset == func
+
+
+def test_import_function_need_full_import_path():
+    with pytest.raises(ValueError):
+        import_function("open_dataset")
+
+
+def test_import_function_exists():
+    with pytest.raises(ImportError):
+        import_function("aaa.bbb.ccc.dummy")


### PR DESCRIPTION
@benjaminleighton I have implemented the changes to `SourceFile` we have discussed today. This object now has a `reader` optional field defaulting to `"xarray.open_dataset"` where you can define the reader function you want to use to open a file or file-like object into a Dataset. Some example using `"xarray.open_mfdataset"` is defined [here](https://github.com/rom-py/rompy/blob/flixible-souce-file/tests/test_data.py#L141-L147).

The approach you have implemented in https://github.com/rom-py/rompy/pull/34 is also perfectly valid and would work fine. My personal preference though would be generalising `SourceFile` a bit as implemented here, and having less of these `Source` objects which should really only handle a few specific corner cases - for most cases we should be able to abstract other complexities using `intake` (I agree for example with the good suggestion from @pbranson in https://github.com/rom-py/rompy/issues/33).

The new [reader](https://github.com/rom-py/rompy/blob/flixible-souce-file/rompy/core/data.py#L87-L95) field could also be passed as the function callable itself rather than a string, in case you are working programmatically from a Notebook for example.