### PR TITLE
Fix bug in ordering of args when rendering SwanConfigComponents using a DataBoundary

### DIFF
--- a/rompy/swan/interface.py
+++ b/rompy/swan/interface.py
@@ -67,7 +67,7 @@ class BoundaryInterface(RompyBaseModel):
     )
     kind: DataBoundary = Field(default=None, description="Boundary data object")
 
-    def get(self, grid: SwanGrid, period: TimeRange, staging_dir: Path):
+    def get(self, staging_dir: Path, grid: SwanGrid, period: TimeRange):
         self.kind._filter_grid(grid)
         self.kind._filter_time(period)
         return self.kind.get(staging_dir, grid)

--- a/tests/swan/test_swan_model.py
+++ b/tests/swan/test_swan_model.py
@@ -5,15 +5,18 @@ import pytest
 import os
 from envyaml import EnvYAML
 
+from rompy.core import SourceIntake
 from rompy.model import ModelRun
 from rompy.swan.config import SwanConfigComponents
-
+from rompy.swan import DataBoundary
+from rompy.swan.interface import BoundaryInterface 
 
 logger = logging.getLogger(__name__)
 
 HERE = Path(__file__).parent
 
 os.environ["ROMPY_PATH"] = str(HERE.parent.parent)
+
 
 
 @pytest.fixture(scope="module")
@@ -28,6 +31,28 @@ def test_swan_model(tmpdir, config_dict):
         cgrid=config_dict["cgrid"],
         inpgrid=config_dict["inpgrid"],
         boundary=config_dict["boundary"],
+        initial=config_dict["initial"],
+        physics=config_dict["physics"],
+        prop=config_dict["prop"],
+        numeric=config_dict["numeric"],
+        output=config_dict["output"],
+        lockup=config_dict["lockup"],
+    )
+    model = ModelRun(
+        run_id="test",
+        period=dict(start="20230101T00", duration="12h", interval="1h"),
+        output_dir=str(tmpdir),
+        config=config,
+    )
+    model.generate()
+
+def test_swan_model_boundary(tmpdir, config_dict):
+    config = SwanConfigComponents(
+        template=str(HERE / "../../rompy/templates/swancomp"),
+        startup=config_dict["startup"],
+        cgrid=config_dict["cgrid"],
+        inpgrid=config_dict["inpgrid"],
+        boundary=BoundaryInterface(kind=DataBoundary(id='wave_forcing', source=SourceIntake(dataset_id='ausspec', catalog_uri=HERE / '../data/catalog.yaml'))),
         initial=config_dict["initial"],
         physics=config_dict["physics"],
         prop=config_dict["prop"],


### PR DESCRIPTION
Changed order of BoundaryInterface get method to match expectation in __call__ in SwanConfigComponents on order of arguments to boundary.render. This aligns the order with DataInterface and ingrid. This fixes a bug in rendering SwanConfigComponents 
