### PR TITLE
Regular grid initialisation from x, y

### DIFF
--- a/rompy/core/grid.py
+++ b/rompy/core/grid.py
@@ -251,9 +251,7 @@ class RegularGrid(BaseGrid):
         self.ny, self.nx = self.x.shape
         self.x0 = self.x[0, 0]
         self.y0 = self.y[0, 0]
-        dx = self.x[0, 1] - self.x0
-        dy = self.y[0, 1] - self.y0
-        self.rot = np.degrees(np.arctan2(dy, dx))
+        self.rot = np.degrees(np.arctan2(self.y[0, 1] - self.y0, self.x[0, 1] - self.x0))
         self.dx = np.sqrt((self.x[0, 1] - self.x0)**2 + (self.y[0, 1] - self.y0)**2)
         self.dy = np.sqrt((self.x[1, 0] - self.x0)**2 + (self.y[1, 0] - self.y0)**2)
 

--- a/rompy/core/grid.py
+++ b/rompy/core/grid.py
@@ -225,13 +225,6 @@ class RegularGrid(BaseGrid):
     ny: Optional[int] = Field(
         default=None, description="Number of grid points in the y direction"
     )
-    _x0: Optional[float]
-    _y0: Optional[float]
-    _rot: Optional[float]
-    _dx: Optional[float]
-    _dy: Optional[float]
-    _nx: Optional[int]
-    _ny: Optional[int]
 
     @model_validator(mode="before")
     @classmethod
@@ -251,13 +244,6 @@ class RegularGrid(BaseGrid):
     def __init__(self, **data):
         super().__init__(**data)
         if not isinstance(self.x, np.ndarray) or not isinstance(self.y, np.ndarray):
-            self._x0 = self.x0
-            self._y0 = self.y0
-            self._rot = self.rot
-            self._dx = self.dx
-            self._dy = self.dy
-            self._nx = self.nx
-            self._ny = self.ny
             self._regen_grid()
 
     def _regen_grid(self):

--- a/rompy/core/grid.py
+++ b/rompy/core/grid.py
@@ -226,30 +226,36 @@ class RegularGrid(BaseGrid):
         default=None, description="Number of grid points in the y direction"
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_grid(cls, data: Any) -> Any:
+    @model_validator(mode="after")
+    def generate(self):
+        """Generate the grid from the provided parameters."""
         keys = ["x0", "y0", "dx", "dy", "nx", "ny"]
-        if data.get("x") is not None or data.get("y") is not None:
-            if any(data.get(key) is not None for key in keys):
-                raise ValueError(
-                    f"x, y provided explicitly, can't process {','.join(keys)}"
-                )
-            return data
-        for var in keys:
-            if data.get(var) is None:
-                raise ValueError(f"{','.join(keys)} must be provided for REG grid")
-        return data
-
-    def __init__(self, **data):
-        super().__init__(**data)
-        if not isinstance(self.x, np.ndarray) or not isinstance(self.y, np.ndarray):
-            self._regen_grid()
+        if self.x is not None and self.y is not None:
+            for key in keys:
+                if getattr(self, key) is not None:
+                    logger.warning(f"x, y provided explicitly, can't process {key}")
+            self._attrs_from_xy()
+        elif None in [getattr(self, key) for key in keys]:
+            raise ValueError(f"All of {','.join(keys)} must be provided for REG grid")
+        # Ensure x, y 2D coordinates are defined
+        self._regen_grid()
+        return self
 
     def _regen_grid(self):
         _x, _y = self._gen_reg_cgrid()
         self.x = _x
         self.y = _y
+
+    def _attrs_from_xy(self):
+        """Generate regular grid attributes from x, y coordinates."""
+        self.ny, self.nx = self.x.shape
+        self.x0 = self.x[0, 0]
+        self.y0 = self.y[0, 0]
+        dx = self.x[0, 1] - self.x0
+        dy = self.y[0, 1] - self.y0
+        self.rot = np.degrees(np.arctan2(dy, dx))
+        self.dx = np.sqrt((self.x[0, 1] - self.x0)**2 + (self.y[0, 1] - self.y0)**2)
+        self.dy = np.sqrt((self.x[1, 0] - self.x0)**2 + (self.y[1, 0] - self.y0)**2)
 
     @property
     def xlen(self):
@@ -286,12 +292,10 @@ class RegularGrid(BaseGrid):
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
+    import copy
 
-    # model = BaseModel()
-    x = np.array([0, 1, 2, 3])
-    y = np.array([0, 1, 2, 3])
-    xx, yy = np.meshgrid(x, y)
-    grid = BaseGrid(x=xx, y=yy)
-    grid.plot()
-    plt.show()
+    grid0 = RegularGrid(x0=-1, y0=1, rot=35, nx=10, ny=10, dx=1, dy=2)
+    grid1 = RegularGrid(x=grid0.x, y=grid0.y)
+
+    # print(grid0.rot, grid1.rot)
+    # print(grid0.dx, grid0.dy, grid1.dx, grid1.dy)

--- a/rompy/swan/components/physics.py
+++ b/rompy/swan/components/physics.py
@@ -1,7 +1,7 @@
 """Model physics components."""
 import logging
 from typing import Any, Literal, Optional, Union, Annotated
-from pydantic import field_validator, model_validator, Field, FieldValidationInfo
+from pydantic import field_validator, model_validator, Field, ValidationInfo
 
 from rompy.swan.components.base import BaseComponent
 from rompy.swan.types import IDLA, PhysicsOff
@@ -1552,7 +1552,7 @@ class VEGETATION(BaseComponent):
 
     @field_validator("height", "diamtr", "drag", "nstems")
     @classmethod
-    def number_of_layers(cls, v: Any, info: FieldValidationInfo) -> Any:
+    def number_of_layers(cls, v: Any, info: ValidationInfo) -> Any:
         if v is None:
             return v
         elif not isinstance(v, list):

--- a/tests/swan/swan_model.yml
+++ b/tests/swan/swan_model.yml
@@ -233,7 +233,7 @@ numeric:
     npnts: 99.5
     mode:
       model_type: nonstat
-      mxitst: 3
+      mxitns: 3
     limiter: 0.1
   dirimpl:
     cdd: 0.5

--- a/tests/test_basegrid.py
+++ b/tests/test_basegrid.py
@@ -22,6 +22,15 @@ def regulargrid():
     return RegularGrid(x0=x0, y0=y0, dx=dx, dy=dy, nx=nx, ny=ny)
 
 
+def test_regulargrid_xy(regulargrid):
+    grid = RegularGrid(x=regulargrid.x, y=regulargrid.y)
+    assert np.array_equal(grid.x, regulargrid.x)
+    assert np.array_equal(grid.y, regulargrid.y)
+    assert grid.nx == regulargrid.nx
+    assert grid.ny == regulargrid.ny
+    for attr in ["x0", "y0", "dx", "dy", "rot"]:
+        assert getattr(grid, attr) == pytest.approx(getattr(regulargrid, attr))
+
 def test_bbox(grid):
     assert grid.bbox() == [0.0, 0.0, 9.0, 9.0]
 


### PR DESCRIPTION
Regular grid was not initialising correctly with fields `x` and `y`. The other fields were not being correctly assigned and this was causing errors when certain attributes that depended on those fields were attempted to be accessed.

This pull request is mainly to fix this behaviour. Some hidden attributes in RegularGrid were also not being used and were also removed.