### PR TITLE
Serializable slices

### DIFF
--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 from rompy.core.filters import Filter
 from rompy.core.grid import BaseGrid, RegularGrid
 from rompy.core.time import TimeRange
-from rompy.core.types import RompyBaseModel, DatasetCoords
+from rompy.core.types import RompyBaseModel, DatasetCoords, Slice
 
 
 logger = logging.getLogger(__name__)
@@ -327,12 +327,15 @@ class DataGrid(DataBlob):
         """Define the filters to use to extract data to this grid"""
         x0, y0, x1, y1 = grid.bbox(buffer=self.buffer)
         self.filter.crop.update(
-            {self.coords.x: slice(x0, x1), self.coords.y: slice(y0, y1)}
+            {
+                self.coords.x: Slice(start=x0, stop=x1),
+                self.coords.y: Slice(start=y0, stop=y1),
+            }
         )
 
     def _filter_time(self, time: TimeRange):
         """Define the filters to use to extract data to this grid"""
-        self.filter.crop.update({self.coords.t: slice(time.start, time.end)})
+        self.filter.crop.update({self.coords.t: Slice(start=time.start, stop=time.end)})
 
     @property
     def ds(self):

--- a/rompy/core/filters.py
+++ b/rompy/core/filters.py
@@ -12,9 +12,7 @@ import xarray as xr
 
 from .types import RompyBaseModel, Slice
 
-from pydantic import (
-    validator,
-)
+from pydantic import field_validator
 
 
 # pydantic class to apply all the filters to the dataset
@@ -26,7 +24,7 @@ class Filter(RompyBaseModel):
     rename: Optional[dict] = {}
     derived: Optional[dict] = {}
 
-    @validator('crop', pre=True)
+    @field_validator("crop", mode="before")
     def convert_slices(cls, v):
         for key, value in v.items():
             if isinstance(value, slice):

--- a/rompy/core/filters.py
+++ b/rompy/core/filters.py
@@ -31,6 +31,8 @@ class Filter(RompyBaseModel):
         for key, value in v.items():
             if isinstance(value, slice):
                 v[key] = Slice.from_slice(value)
+            if isinstance(value, dict):
+                v[key] = Slice.from_dict(value)
         return v
 
     def __call__(self, ds):

--- a/rompy/core/filters.py
+++ b/rompy/core/filters.py
@@ -10,7 +10,11 @@ from typing import Optional
 
 import xarray as xr
 
-from .types import RompyBaseModel
+from .types import RompyBaseModel, Slice
+
+from pydantic import (
+    validator,
+)
 
 
 # pydantic class to apply all the filters to the dataset
@@ -21,6 +25,13 @@ class Filter(RompyBaseModel):
     timenorm: Optional[dict] = {}
     rename: Optional[dict] = {}
     derived: Optional[dict] = {}
+
+    @validator('crop', pre=True)
+    def convert_slices(cls, v):
+        for key, value in v.items():
+            if isinstance(value, slice):
+                v[key] = Slice.from_slice(value)
+        return v
 
     def __call__(self, ds):
         filters = get_filter_fns()

--- a/rompy/core/filters.py
+++ b/rompy/core/filters.py
@@ -25,7 +25,7 @@ class Filter(RompyBaseModel):
     def __call__(self, ds):
         filters = get_filter_fns()
         for fn in filters:
-            params = self.model_dump()[fn]
+            params = getattr(self, fn)
             if params:
                 ds = filters[fn](ds, **params)
         return ds
@@ -110,7 +110,11 @@ def crop_filter(ds, **data_slice) -> xr.Dataset:
 
     """
     if data_slice is not None:
-        this_crop = {k: data_slice[k] for k in data_slice.keys() if k in ds.dims.keys()}
+        this_crop = {
+            k: data_slice[k].to_slice()
+            for k in data_slice.keys()
+            if k in ds.dims.keys()
+        }
         ds = ds.sel(this_crop)
         for k in data_slice.keys():
             if (k not in ds.dims.keys()) and (k in ds.coords.keys()):
@@ -195,3 +199,5 @@ def _open_preprocess(url, chunks, filters, xarray_kwargs):
         ds = fn(ds, **params)
 
     return ds
+
+

--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -7,7 +7,6 @@ from pydantic import (
     ConfigDict,
     BaseModel,
     Field,
-    validator,
 )
 
 
@@ -318,8 +317,12 @@ class DatasetCoords(RompyBaseModel):
 class Slice(BaseModel):
     """Basic float or datetime slice representation"""
 
-    start: Optional[Union[float, datetime, str]] = None
-    stop: Optional[Union[float, datetime, str]] = None
+    start: Optional[Union[float, datetime, str]] = Field(
+        default=None, description="Slice start"
+    )
+    stop: Optional[Union[float, datetime, str]] = Field(
+        default=None, description="Slice stop"
+    )
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -322,6 +322,10 @@ class Slice(BaseModel):
     stop: Optional[Union[float, datetime, str]] = None
 
     @classmethod
+    def from_dict(cls, d: dict):
+        return cls(start=d['start'], stop=d['stop'])
+    
+    @classmethod
     def from_slice(cls, s: slice):
         return cls(start=s.start, stop=s.stop)
 

--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -1,5 +1,6 @@
 """Rompy types."""
-from typing import Any, Optional
+from typing import Any, Optional, Union
+from datetime import datetime
 from pydantic import (
     field_validator,
     model_validator,
@@ -11,7 +12,6 @@ from pydantic import (
 
 
 class RompyBaseModel(BaseModel):
-
     # The config below prevents https://github.com/pydantic/pydantic/discussions/7121
     model_config = ConfigDict(protected_namespaces=())
 
@@ -313,3 +313,30 @@ class DatasetCoords(RompyBaseModel):
     x: Optional[str] = Field("longitude", description="Name of the x coordinate")
     y: Optional[str] = Field("latitude", description="Name of the y coordinate")
     z: Optional[str] = Field("depth", description="Name of the z coordinate")
+
+
+class Slice(BaseModel):
+    """Basic float or datetime slice representation"""
+
+    start: Optional[Union[float, datetime]] = None
+    stop: Optional[Union[float, datetime]] = None
+
+    @classmethod
+    def from_slice(cls, s: slice):
+        return cls(start=s.start, stop=s.stop)
+
+    def to_slice(self) -> slice:
+        return slice(self.start, self.stop)
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if isinstance(v, slice):
+            return cls.from_slice(v)
+        elif isinstance(v, cls):
+            return v
+        else:
+            raise ValueError(f"Cannot convert {type(v)} to Slice")

--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -318,8 +318,8 @@ class DatasetCoords(RompyBaseModel):
 class Slice(BaseModel):
     """Basic float or datetime slice representation"""
 
-    start: Optional[Union[float, datetime]] = None
-    stop: Optional[Union[float, datetime]] = None
+    start: Optional[Union[float, datetime, str]] = None
+    stop: Optional[Union[float, datetime, str]] = None
 
     @classmethod
     def from_slice(cls, s: slice):

--- a/rompy/swan/components/group.py
+++ b/rompy/swan/components/group.py
@@ -545,7 +545,10 @@ class OUTPUT(BaseGroupComponent):
     def write_locations_exists(self) -> "OUTPUT":
         """Ensure the location component requested by a write component exists."""
         for write in self.write_set:
-            sname = getattr(self, write).sname
+            obj = getattr(self, write)
+            if obj is None:
+                continue
+            sname = obj.sname
             if sname in SPECIAL_NAMES:
                 return self
             try:
@@ -635,7 +638,10 @@ class OUTPUT(BaseGroupComponent):
         """List of snames from specified location components."""
         snames = []
         for field in self.locations_set:
-            sname = getattr(self, field).sname
+            obj = getattr(self, field)
+            if obj is None:
+                continue
+            sname = obj.sname
             if isinstance(sname, str):
                 sname = [sname]
             snames.extend(sname)
@@ -645,6 +651,8 @@ class OUTPUT(BaseGroupComponent):
         """Filter the location component defined with the specified sname."""
         for field in self.locations_set:
             obj = getattr(self, field)
+            if obj is None:
+                continue
             obj_snames = obj.sname if isinstance(obj.sname, list) else [obj.sname]
             for obj_sname in obj_snames:
                 if obj_sname == sname:


### PR DESCRIPTION
Filter objects used in DataGrid.filter have a dictionary Filter.crop that typically consists of variable names as keys and slice objects as values. In Filter.crop is used when Filter.crop_filter is applied on __call__. At this point data is cropped according to specified slices. Python slice objects are not serializable in Pydantic. Thus I've 

Create a serializable class Slice in types. This type can be converted to and from slice objects using the included method and support slicing by float, str or datetime. Furthermore it supports being deserialized from slice objects for programmatic cases where slices are passed as key value args in a dictionary to an object that creates a hierarchy with a Slice object in it. Additional Filter objects have a validator that will convert slice objects in the crop dictionary supporting legacy slice objects in tests but also allowing this as a valid use. 

Additionally this pull request contains a minor bug fix to groups allowing some properties to be None on deserialization from json or yaml.  