### PR TITLE
fix assumption that coords are named latitude and longitude

### DIFF
--- a/rompy/schism/data.py
+++ b/rompy/schism/data.py
@@ -70,8 +70,8 @@ class SfluxSource(DataGrid):
             variables=self.variables, filters=self.filter, coords=self.coords
         )
         # rename latitude and longitide to lat and lon
-        ds = ds.rename_dims({"latitude": "ny_grid", "longitude": "nx_grid"})
-        lon, lat = np.meshgrid(ds["longitude"], ds["latitude"])
+        ds = ds.rename_dims({self.coords.y: "ny_grid", self.coords.x: "nx_grid"})
+        lon, lat = np.meshgrid(ds[self.coords.x], ds[self.coords.y])
         ds["lon"] = (("ny_grid", "nx_grid"), lon)
         ds["lat"] = (("ny_grid", "nx_grid"), lat)
         basedate = pd.to_datetime(ds.time.values[0])


### PR DESCRIPTION
Uses the coords field to get coordinate names which means they can be something other than latitude and longitude in the source dataset. 