### PR TITLE
Datamesh

### DIFF
--- a/rompy/core/boundary.py
+++ b/rompy/core/boundary.py
@@ -270,12 +270,12 @@ class BoundaryWaveStation(DataBoundary):
         ),
     )
 
-    @model_validator(mode="after")
-    def assert_has_wavespectra_accessor(self) -> "BoundaryWaveStation":
-        dset = self.source.open()
-        if not hasattr(dset, "spec"):
-            raise ValueError(f"Wavespectra compatible source is required")
-        return self
+    # @model_validator(mode="after")
+    # def assert_has_wavespectra_accessor(self) -> "BoundaryWaveStation":
+    #     dset = self.source.open()
+    #     if not hasattr(dset, "spec"):
+    #         raise ValueError(f"Wavespectra compatible source is required")
+    #     return self
 
     def _source_grid_spacing(self, grid) -> float:
         """Return the lowest spacing between points in the source dataset."""

--- a/rompy/core/boundary.py
+++ b/rompy/core/boundary.py
@@ -148,10 +148,6 @@ class DataBoundary(DataGrid):
             raise ValueError("Spacing must be greater than zero")
         return v
 
-    def _filter_grid(self, *args, **kwargs):
-        """Overwrite DataGrid's which assumes a regular grid."""
-        pass
-
     def _source_grid_spacing(self) -> float:
         """Return the lowest grid spacing in the source dataset.
 
@@ -269,6 +265,13 @@ class BoundaryWaveStation(DataBoundary):
             "Wavespectra method to use for selecting boundary points from the dataset"
         ),
     )
+    buffer: float = Field(
+        default=2.0,
+        description="Space to buffer the grid bounding box if `filter_grid` is True",
+    )
+
+    def model_post_init(self, __context):
+        self.variables = ["efth", "lon", "lat"]
 
     # @model_validator(mode="after")
     # def assert_has_wavespectra_accessor(self) -> "BoundaryWaveStation":
@@ -345,8 +348,11 @@ class BoundaryWaveStation(DataBoundary):
             Path to the netcdf file.
 
         """
-        if self.crop_data and time is not None:
-            self._filter_time(time)
+        if self.crop_data:
+            if time is not None:
+                self._filter_time(time)
+            if grid is not None:
+                self._filter_grid(grid)
         ds = self._sel_boundary(grid)
         outfile = Path(destdir) / f"{self.id}.nc"
         ds.spec.to_netcdf(outfile)

--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -1,5 +1,6 @@
 """Rompy core data objects."""
 import logging
+from functools import cached_property
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from pathlib import Path
@@ -38,6 +39,11 @@ class SourceBase(RompyBaseModel, ABC):
     def _open(self) -> xr.Dataset:
         """This abstract private method should return a xarray dataset object."""
         pass
+
+    @cached_property
+    def coordinates(self) -> xr.Dataset:
+        """Return the coordinates of the datasource."""
+        return self.open().coords
 
     def open(self, variables: list = [], filters: Filter = {}, **kwargs) -> xr.Dataset:
         """Return the filtered dataset object.
@@ -182,10 +188,15 @@ class SourceDatamesh(SourceBase):
     def __str__(self) -> str:
         return f"SourceDatamesh(datasource={self.datasource})"
 
-    @property
+    @cached_property
     def connector(self) -> Connector:
         """The Datamesh connector instance."""
         return Connector(token=self.token, **self.kwargs)
+
+    @cached_property
+    def coordinates(self) -> xr.Dataset:
+        """Return the coordinates of the datasource."""
+        return self._open(variables=[], geofilter=None, timefilter=None).coords
 
     def _geofilter(self, filters: Filter, coords: DatasetCoords) -> dict:
         """The Datamesh geofilter."""

--- a/rompy/core/filters.py
+++ b/rompy/core/filters.py
@@ -124,7 +124,7 @@ def crop_filter(ds, **data_slice) -> xr.Dataset:
         this_crop = {
             k: data_slice[k].to_slice()
             for k in data_slice.keys()
-            if k in ds.dims.keys()
+            if k in ds.sizes.keys()
         }
         ds = ds.sel(this_crop)
         for k in data_slice.keys():

--- a/rompy/swan/boundary.py
+++ b/rompy/swan/boundary.py
@@ -270,6 +270,8 @@ class BoundspecSide(BoundspecBase):
         """
         if self.crop_data and time is not None:
             self._filter_time(time)
+        if self.crop_data and grid is not None:
+            self._filter_grid(grid)
         ds = self._sel_boundary(grid).sortby("dir")
 
         cmds = []
@@ -360,6 +362,8 @@ class BoundspecSegmentXY(BoundspecBase):
         """
         if self.crop_data and time is not None:
             self._filter_time(time)
+        if self.crop_data and grid is not None:
+            self._filter_grid(grid)
         ds = self._sel_boundary(grid).sortby("dir")
 
         # If nearest, ensure points are returned at the requested positions

--- a/rompy/swan/boundary.py
+++ b/rompy/swan/boundary.py
@@ -80,6 +80,8 @@ class Boundnest1(BoundaryWaveStation):
         """
         if self.crop_data and time is not None:
             self._filter_time(time)
+        if self.crop_data and grid is not None:
+            self._filter_grid(grid)
 
         ds = self._sel_boundary(grid).sortby("dir")
 

--- a/rompy/swan/data.py
+++ b/rompy/swan/data.py
@@ -327,7 +327,7 @@ class Swan_accessor(object):
         ds = self._obj
 
         # ds = ds.transpose((time,) + ds[x].dims)
-        dt = np.diff(ds[time].values).mean() / pd.to_timedelta(1, "H")
+        dt = np.diff(ds[time].values).mean() / pd.to_timedelta(1, "h")
 
         inptimes = []
         with open(output_file, "wt") as f:


### PR DESCRIPTION
A few changes to fix the datamesh source objects. One change concerns schism @tomdurrant which is the removal of the time offset logic from the _filter_time() method (https://github.com/rom-py/rompy/compare/raf-data?expand=1#diff-1ea32bb20ed105e939a30996d7a70cd9dfa420c2328c750a2035be817fda18d9R372-L393). In order to achieve the same result now, the time buffer now needs to be specified as the number of seconds, instead of a multiplier for the timestep calculated from the data (https://github.com/rom-py/rompy/compare/raf-data?expand=1#diff-1ea32bb20ed105e939a30996d7a70cd9dfa420c2328c750a2035be817fda18d9L365-L368). Ultimately, the data filtering option probably needs some rethinking. Ideally we should be able to be more flexible and deal with longitude conventions, non-matching slices, etc.