### PR TITLE
Add draft attempt for a plugin architecture

### DIFF
--- a/rompy/dummy_config.py
+++ b/rompy/dummy_config.py
@@ -38,3 +38,7 @@ if __name__ == "__main__":
         print(ModelRun(**kwargs))
     except ValidationError as e:
         print(e)
+
+    kwargs = {"config": {"model_type": "xbeach"}}
+    mr = ModelRun(**kwargs)
+    print(mr.dummy_property)

--- a/rompy/dummy_config.py
+++ b/rompy/dummy_config.py
@@ -1,0 +1,43 @@
+"""A dummy config module using defining and registering some dummy Config classes."""
+from typing import Literal
+from pydantic import BaseModel
+
+from rompy.registry import register_type
+from rompy.dummy_model import create_model_run
+
+
+@register_type("swan")
+class SwanConfig(BaseModel):
+    model_type: Literal["swan"]
+
+
+@register_type("schism")
+class SchismConfig(BaseModel):
+    model_type: Literal["schism"]
+
+
+@register_type("xbeach")
+class XbeachConfig(BaseModel):
+    model_type: Literal["xbeach"]
+
+
+ModelRun = create_model_run()
+
+
+if __name__ == "__main__":
+
+    kwargs = {"config": {"model_type": "swan"}}
+    print(ModelRun(**kwargs))
+
+    kwargs = {"config": {"model_type": "schism"}}
+    print(ModelRun(**kwargs))
+
+    kwargs = {"config": {"model_type": "xbeach"}}
+    print(ModelRun(**kwargs))
+
+    from pydantic import ValidationError
+    try:
+        kwargs = {"config": {"model_type": "foo"}}
+        print(ModelRun(**kwargs))
+    except ValidationError as e:
+        print(e)

--- a/rompy/dummy_config.py
+++ b/rompy/dummy_config.py
@@ -1,31 +1,27 @@
-"""A dummy config module using defining and registering some dummy Config classes."""
 from typing import Literal
+
 from pydantic import BaseModel
 
-from rompy.registry import register_type
-from rompy.dummy_model import create_model_run
+from rompy.dummy_model import ModelRun
+from rompy.registry import TypeRegistry
 
 
-@register_type("swan")
+@TypeRegistry.register("swan")
 class SwanConfig(BaseModel):
-    model_type: Literal["swan"]
+    model_type: Literal["swan"] = "swan"
 
 
-@register_type("schism")
+@TypeRegistry.register("schism")
 class SchismConfig(BaseModel):
-    model_type: Literal["schism"]
+    model_type: Literal["schism"] = "schism"
 
 
-@register_type("xbeach")
+@TypeRegistry.register("xbeach")
 class XbeachConfig(BaseModel):
-    model_type: Literal["xbeach"]
-
-
-ModelRun = create_model_run()
+    model_type: Literal["xbeach"] = "xbeach"
 
 
 if __name__ == "__main__":
-
     kwargs = {"config": {"model_type": "swan"}}
     print(ModelRun(**kwargs))
 
@@ -36,6 +32,7 @@ if __name__ == "__main__":
     print(ModelRun(**kwargs))
 
     from pydantic import ValidationError
+
     try:
         kwargs = {"config": {"model_type": "foo"}}
         print(ModelRun(**kwargs))

--- a/rompy/dummy_model.py
+++ b/rompy/dummy_model.py
@@ -23,4 +23,10 @@ class ModelRunProxy:
 
 
 class ModelRun(metaclass=ModelRunMeta):
-    pass
+
+    def dummy_method(self):
+        print("dummy")
+
+    @property
+    def dummy_property(self):
+        return "dummy"

--- a/rompy/dummy_model.py
+++ b/rompy/dummy_model.py
@@ -1,16 +1,26 @@
-"""This is where the ModelRun class will be defined."""
-from typing import Union
-from pydantic import create_model, Field
-
+# dummy_model.py
 from rompy.registry import TypeRegistry
 
 
-def create_model_run():
-    """Dynamically generate the ModelRun class."""
-    types = TypeRegistry.get_types()
-    config_type = Union[tuple(types.values())]
-    
-    return create_model(
-        "ModelRun",
-        config=(config_type, Field(..., discriminator='model_type'))
-    )
+class ModelRunMeta(type):
+    def __new__(mcs, name, bases, attrs):
+        return ModelRunProxy
+
+
+class ModelRunProxy:
+    def __new__(cls, *args, **kwargs):
+        actual_model_run = TypeRegistry.create_model_run()
+        return actual_model_run(*args, **kwargs)
+
+    def __getattr__(name):
+        actual_model_run = TypeRegistry.create_model_run()
+        return getattr(actual_model_run, name)
+
+    @classmethod
+    def __class_getitem__(cls, key):
+        actual_model_run = TypeRegistry.create_model_run()
+        return actual_model_run.__class_getitem__(key)
+
+
+class ModelRun(metaclass=ModelRunMeta):
+    pass

--- a/rompy/dummy_model.py
+++ b/rompy/dummy_model.py
@@ -1,0 +1,16 @@
+"""This is where the ModelRun class will be defined."""
+from typing import Union
+from pydantic import create_model, Field
+
+from rompy.registry import TypeRegistry
+
+
+def create_model_run():
+    """Dynamically generate the ModelRun class."""
+    types = TypeRegistry.get_types()
+    config_type = Union[tuple(types.values())]
+    
+    return create_model(
+        "ModelRun",
+        config=(config_type, Field(..., discriminator='model_type'))
+    )

--- a/rompy/registry.py
+++ b/rompy/registry.py
@@ -1,0 +1,23 @@
+from typing import Dict, Type
+from pydantic import BaseModel
+
+
+class TypeRegistry:
+    """A registry to store the types of the models."""
+    _types: Dict[str, Type[BaseModel]] = {}
+
+    @classmethod
+    def register(cls, model_type: str, model_class: Type[BaseModel]):
+        cls._types[model_type] = model_class
+
+    @classmethod
+    def get_types(cls):
+        return cls._types
+
+
+def register_type(model_type: str):
+    """A decorator to register a new type in the registry."""
+    def decorator(cls):
+        TypeRegistry.register(model_type, cls)
+        return cls
+    return decorator


### PR DESCRIPTION
This is an initial attempt to define a plugin type architecture to allow defining new model config types (https://github.com/rom-py/rompy/issues/96).

There are three main components in this new approach:

(1) The [registry](https://github.com/rom-py/rompy/blob/plugin/rompy/registry.py) module which holds the type registry objects .
(2) The [model](https://github.com/rom-py/rompy/blob/plugin/rompy/dummy_model.py) module where the ``ModelRun`` object is defined so it can be dynamically generated using ``pydantic.create_model``. The supported types are handled by the ``rompy.registry.TypeRegistry`` class.
(3) The [config](https://github.com/rom-py/rompy/blob/plugin/rompy/dummy_config.py) module where the model config object(s) should be defined. The function to dynamically create ``ModelRun`` needs to be run after defining the Config type(s). The Config type(s) need to be decorated using the ``rompy.registry.register_type`` function.

The idea here is that (1) and (2) do not change, all the user needs to do when defining a new model config object in (3) is:
- Import the type register decorator (`rompy.registry.register_type`)
- Define the Config objects using this decorator (such as in [this example](https://github.com/rom-py/rompy/blob/plugin/rompy/dummy_config.py#L9-L11)).
- Generate the ``ModelRun`` object after the model config has been defined (as shown [here](https://github.com/rom-py/rompy/blob/plugin/rompy/dummy_config.py#L24)).
