### PR TITLE
Added custom model_dump and model_dump_json methods

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,7 +8,7 @@ Core Classes
 
 Model
 ~~~~~
-.. automodule:: rompy.model
+.. automodule:: rompy.model.ModelRun
     :members:
     :inherited-members: BaseModel
     :no-index:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,7 +135,7 @@ texinfo_documents = [
 
 autoclass_content = "class"
 
-autodoc_pydantic_model_show_json = False
+autodoc_pydantic_model_show_json = True
 autodoc_pydantic_model_show_config_summary = False
 autodoc_pydantic_settings_show_validator_summary = True
 man_pages = [(master_doc, "rompy", "Rompy Documentation", [author], 1)]

--- a/docs/source/core_concepts.rst
+++ b/docs/source/core_concepts.rst
@@ -13,6 +13,7 @@ concepts:
 
     rompy.model.ModelRun
     rompy.core.BaseConfig
+    rompy.core.dummy.DemoModel
 
 There is information about each of these in the documentation of each object, but at a
 high level, ModelRun is the high level framework that renders the config object and controls the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ The final main component of the library is an intake driver that builds on the i
     models
     demo
     api
+    relational_diagrams
 
 Indices and tables
 ==================

--- a/rompy/core/time.py
+++ b/rompy/core/time.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Optional, Union
 
-from pydantic import field_validator, model_validator, ConfigDict, BaseModel, Field
-
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 time_units = {
     "h": "hours",
@@ -39,35 +38,26 @@ class TimeRange(BaseModel):
     """
 
     start: Optional[datetime] = Field(
-        None,
-        description="The start date of the time range",
-        examples=["2020-01-01"],
+        None, description="The start date of the time range", examples=["2020-01-01"]
     )
     end: Optional[datetime] = Field(
-        None,
-        description="The end date of the time range",
-        examples=["2020-01-02"],
+        None, description="The end date of the time range", examples=["2020-01-02"]
     )
     duration: Optional[Union[str, timedelta]] = Field(
-        None,
-        description="The duration of the time range",
-        examples=["1d"],
+        None, description="The duration of the time range", examples=["1d"]
     )
     interval: Optional[Union[str, timedelta]] = Field(
-        "1h",
-        description="The frequency of the time range",
-        examples=["1h", "'1h'"],
+        "1h", description="The frequency of the time range", examples=["1h", "'1h'"]
     )
     include_end: bool = Field(
-        True,
-        description="Determines if the end date should be included in the range",
+        True, description="Determines if the end date should be included in the range"
     )
     model_config = ConfigDict(validate_default=True)
 
     @field_validator("interval", "duration", mode="before")
     @classmethod
     def valid_duration_interval(cls, v):
-        if v == None:
+        if v is None:
             return v
         if isinstance(v, timedelta):
             return v
@@ -83,7 +73,7 @@ class TimeRange(BaseModel):
     @field_validator("start", "end", mode="before")
     @classmethod
     def validate_start_end(cls, v):
-        if v == None:
+        if v is None:
             return v
         if isinstance(v, datetime):
             return v
@@ -100,52 +90,63 @@ class TimeRange(BaseModel):
             "%Y-%m-%dT%H%M",
         ]:
             try:
-                ret = datetime.strptime(v, fmt)
-                return ret
+                return datetime.strptime(v, fmt)
             except ValueError:
-                pass
+                continue
         return v
 
     @model_validator(mode="before")
     @classmethod
     def validate_start_end_duration(cls, data: Any) -> Any:
-        if data.get("start") is not None:
-            if all(data.get(key) is None for key in ["end", "duration"]):
-                raise ValueError("start provided, must provide either end or duration")
-        if data.get("end") is not None:
-            if all(data.get(key) is None for key in ["start", "duration"]):
-                raise ValueError("end provided, must provide either start or duration")
-        if data.get("duration") is not None:
-            if all(data.get(key) is None for key in ["start", "end"]):
-                raise ValueError("duration provided, must provide either start or end")
-        if all(data.get(key) is None for key in ["start", "end", "duration"]):
+        start, end, duration = data.get("start"), data.get("end"), data.get("duration")
+        if start and not (end or duration):
+            raise ValueError("start provided, must provide either end or duration")
+        if end and not (start or duration):
+            raise ValueError("end provided, must provide either start or duration")
+        if duration and not (start or end):
+            raise ValueError("duration provided, must provide either start or end")
+        if not (start or end or duration):
             raise ValueError("Must provide two of start, end, duration")
-        if all(data.get(key) is not None for key in ["start", "end", "duration"]):
+        if start and end and duration:
             raise ValueError("Must provide only two of start, end, duration")
         return data
 
     @model_validator(mode="after")
     def parse_start_end_duration(self) -> "TimeRange":
-        if self.start is not None and self.end is not None:
+        if self.start and self.end and not self.duration:
             self.duration = self.end - self.start
-        if self.start is not None and self.duration is not None:
+        elif self.start and self.duration and not self.end:
             self.end = self.start + self.duration
-        if self.end is not None and self.duration is not None:
+        elif self.end and self.duration and not self.start:
             self.start = self.end - self.duration
         return self
 
+    def model_dump(self, *args, **kwargs):
+        excludable_fields = {"duration"} if self.start and self.end else set()
+        return super().model_dump(*args, **{**kwargs, "exclude": excludable_fields})
+
+    def model_dump_json(self, *args, **kwargs):
+        excludable_fields = {"duration"} if self.start and self.end else set()
+        return super().model_dump_json(
+            *args, **{**kwargs, "exclude": excludable_fields}
+        )
+
     @property
     def date_range(self) -> list[datetime]:
-        start = self.start
-        end = self.end
+        if not self.start or not self.end or not self.interval:
+            return []
+        start, end = self.start, self.end
+        step_size = (
+            self.interval
+            if isinstance(self.interval, timedelta)
+            else timedelta(**{time_units[self.interval[-1]]: int(self.interval[:-1])})
+        )
         date_range = []
-        while start < end:
+        while start <= end:
             date_range.append(start)
-            start += self.interval
-            if start + self.interval > end:
-                if self.include_end:
-                    date_range.append(end)
-                break
+            start += step_size
+        if self.include_end and date_range and date_range[-1] != end:
+            date_range.append(end)
         return date_range
 
     def contains(self, date: datetime) -> bool:
@@ -155,16 +156,13 @@ class TimeRange(BaseModel):
         return self.contains(date_range.start) and self.contains(date_range.end)
 
     def common_times(self, date_range: "TimeRange") -> list[datetime]:
-        common_times = []
-        for date in self.date_range:
-            if date_range.contains(date):
-                common_times.append(date)
-        return common_times
+        return [date for date in self.date_range if date_range.contains(date)]
 
     def __str__(self):
-        ret = f"\n\tStart: {self.start}\n"
-        ret += f"\tEnd: {self.end}\n"
-        ret += f"\tDuration: {self.duration}\n"
-        ret += f"\tInterval: {self.interval}\n"
-        ret += f"\tInclude End: {self.include_end}\n"
-        return ret
+        return (
+            f"\n\tStart: {self.start}\n"
+            f"\tEnd: {self.end}\n"
+            f"\tDuration: {self.duration}\n"
+            f"\tInterval: {self.interval}\n"
+            f"\tInclude End: {self.include_end}\n"
+        )

--- a/rompy/core/time.py
+++ b/rompy/core/time.py
@@ -142,7 +142,7 @@ class TimeRange(BaseModel):
             else timedelta(**{time_units[self.interval[-1]]: int(self.interval[:-1])})
         )
         date_range = []
-        while start <= end:
+        while start < end:
             date_range.append(start)
             start += step_size
         if self.include_end and date_range and date_range[-1] != end:


### PR DESCRIPTION
### Potential Solutions

1. **Conditional Validation:**
    - Use a more advanced validation logic that re-validates after deserialization and handles the presence of all three fields.
  
2. **Custom Serialization/Deserialization Logic:**
    - Modify serialization/deserialization behavior to correctly reconstruct the state without all three fields' presence.

3. **Flag Field Approach:**
    - Introduce a redundant flag field (or simply modify one field for markers), which helps the model figure out if it's being deserialized.

I've implemeted serialization/deserialization logic since it seems most versatile.

### Custom Serialization/Deserialization

Override the serialization process and ensure that saving and loading a `TimeRange` won't include all three fields unless intended for a reconstructed state.

#### Custom Methods

1. **Custom `model_dump` Method:**
   - Conditionally exclude the `duration` field if both `start` and `end` are provided.

2. **Custom `model_dump_json` Method:**
   - Same conditional exclusion in the JSON serialization process.
