### PR TITLE
Multi components

### DIFF
--- a/notebooks/swan/components/output.ipynb
+++ b/notebooks/swan/components/output.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "283e2636",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "id": "6c7aae0b-a773-4f17-8d2f-a51a8d7c43b4",
    "metadata": {},
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "47cd1a9e-8d1f-49a2-be31-218f6ef18cf4",
    "metadata": {},
    "outputs": [
@@ -91,7 +91,7 @@
       "\u001b[0;34m\u001b[0m    \u001b[0mngrid\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mUnion\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNGRID\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNGRID_UNSTRUCTURED\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Ngrid locations component'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdiscriminator\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'model_type'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
       "\u001b[0;34m\u001b[0m    \u001b[0mquantity\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mQUANTITIES\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Quantity component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
       "\u001b[0;34m\u001b[0m    \u001b[0moutput_options\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOUTPUT_OPTIONS\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Output options component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-      "\u001b[0;34m\u001b[0m    \u001b[0mblock\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBLOCK\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Block write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mblock\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mUnion\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBLOCK\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBLOCKS\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Block write component'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdiscriminator\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'model_type'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
       "\u001b[0;34m\u001b[0m    \u001b[0mtable\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTABLE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Table write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
       "\u001b[0;34m\u001b[0m    \u001b[0mspecout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSPECOUT\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Spectra write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
       "\u001b[0;34m\u001b[0m    \u001b[0mnestout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNESTOUT\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Nest write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "id": "5059af97-295d-4348-baf0-845588076c2b",
    "metadata": {},
    "outputs": [
@@ -202,7 +202,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BLOCK sname='compgrid' fname='outgrid.nc' LAYOUT idla=3 &\n",
+      "BLOCK sname='COMPGRID' fname='outgrid.nc' LAYOUT idla=3 &\n",
       "    DEPTH &\n",
       "    WIND &\n",
       "    HSIGN &\n",
@@ -217,7 +217,7 @@
     "# Specifying a single block component\n",
     "\n",
     "block = BLOCK(\n",
-    "    sname=\"compgrid\",\n",
+    "    sname=\"COMPGRID\",\n",
     "    fname=\"outgrid.nc\",\n",
     "    output=[\"depth\", \"wind\", \"hsign\", \"hswell\", \"dir\", \"tps\"],\n",
     "    times=TimeRangeOpen(tfmt=1, dfmt=\"min\"),\n",
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "id": "f5959fe2-5bbb-4944-8b50-effc3bcc8539",
    "metadata": {},
    "outputs": [
@@ -241,23 +241,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BLOCK sname='compgrid' fname='depth.txt' DEPTH\n",
-      "BLOCK sname='compgrid' fname='hsign.txt' HSIGN\n",
-      "BLOCK sname='compgrid' fname='tps.txt' TPS\n",
-      "BLOCK sname='compgrid' fname='dir.txt' DIR\n"
+      "BLOCK sname='COMPGRID' fname='depth.txt' DEPTH\n",
+      "BLOCK sname='COMPGRID' fname='hsign.txt' HSIGN\n",
+      "BLOCK sname='COMPGRID' fname='tps.txt' TPS\n",
+      "BLOCK sname='COMPGRID' fname='dir.txt' DIR\n"
      ]
     }
    ],
    "source": [
     "# Specifying multiple block components\n",
     "\n",
-    "block1 = BLOCK(sname=\"compgrid\", fname=\"depth.txt\", output=[\"depth\"])\n",
-    "block2 = BLOCK(sname=\"compgrid\", fname=\"hsign.txt\", output=[\"hsign\"])\n",
-    "block3 = BLOCK(sname=\"compgrid\", fname=\"tps.txt\", output=[\"tps\"])\n",
-    "block4 = BLOCK(sname=\"compgrid\", fname=\"dir.txt\", output=[\"dir\"])\n",
+    "block1 = BLOCK(sname=\"COMPGRID\", fname=\"depth.txt\", output=[\"depth\"])\n",
+    "block2 = BLOCK(sname=\"COMPGRID\", fname=\"hsign.txt\", output=[\"hsign\"])\n",
+    "block3 = BLOCK(sname=\"COMPGRID\", fname=\"tps.txt\", output=[\"tps\"])\n",
+    "block4 = BLOCK(sname=\"COMPGRID\", fname=\"dir.txt\", output=[\"dir\"])\n",
     "\n",
     "blocks = BLOCKS(components=[block1, block2, block3, block4])\n",
     "print(blocks.render())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "1301a2f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BLOCK sname='COMPGRID' fname='depth.txt' DEPTH\n",
+      "\n",
+      "BLOCK sname='COMPGRID' fname='hsign.txt' HSIGN\n",
+      "\n",
+      "BLOCK sname='COMPGRID' fname='tps.txt' TPS\n",
+      "\n",
+      "BLOCK sname='COMPGRID' fname='dir.txt' DIR\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = OUTPUT(block=blocks)\n",
+    "print(output.render())"
    ]
   }
  ],

--- a/notebooks/swan/components/output.ipynb
+++ b/notebooks/swan/components/output.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f282e073-4210-4cc0-a22a-e2acf95f0ece",
+   "metadata": {},
+   "source": [
+    "# SWAN Output Components\n",
+    "\n",
+    "This notebook shows examples of using the SWAN components to define model output commands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "283e2636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6c7aae0b-a773-4f17-8d2f-a51a8d7c43b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rompy.swan.components.group import OUTPUT\n",
+    "from rompy.swan.subcomponents.time import TimeRangeOpen\n",
+    "from rompy.swan.components.output import (\n",
+    "    SPECIAL_NAMES,\n",
+    "    BaseLocation,\n",
+    "    FRAME,\n",
+    "    GROUP,\n",
+    "    CURVE,\n",
+    "    CURVES,\n",
+    "    RAY,\n",
+    "    ISOLINE,\n",
+    "    POINTS,\n",
+    "    POINTS_FILE,\n",
+    "    NGRID,\n",
+    "    NGRID_UNSTRUCTURED,\n",
+    "    QUANTITY,\n",
+    "    QUANTITIES,\n",
+    "    OUTPUT_OPTIONS,\n",
+    "    BLOCK,\n",
+    "    BLOCKS,\n",
+    "    TABLE,\n",
+    "    SPECOUT,\n",
+    "    NESTOUT,\n",
+    "    TEST,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "526786a3-e758-4449-9cd2-6e5770515c8e",
+   "metadata": {},
+   "source": [
+    "## OUTPUT group component\n",
+    "\n",
+    "The OUTPUT group component provides an interface for the different types of SWAN output commands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "47cd1a9e-8d1f-49a2-be31-218f6ef18cf4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0;31mInit signature:\u001b[0m\n",
+      "\u001b[0mOUTPUT\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0;34m*\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mmodel_type\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mLiteral\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'output'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'OUTPUT'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'output'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mframe\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFRAME\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Frame locations component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mgroup\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mGROUP\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Group locations component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mcurve\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCURVES\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Curve locations component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mray\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mRAY\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Ray locations component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0misoline\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mISOLINE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Isoline locations component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mpoints\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mUnion\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPOINTS\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPOINTS_FILE\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Points locations component'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdiscriminator\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'model_type'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mngrid\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mUnion\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNGRID\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNGRID_UNSTRUCTURED\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Ngrid locations component'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdiscriminator\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'model_type'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mquantity\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mQUANTITIES\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Quantity component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0moutput_options\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOUTPUT_OPTIONS\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Output options component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mblock\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBLOCK\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Block write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mtable\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTABLE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Table write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mspecout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSPECOUT\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Spectra write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mnestout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNESTOUT\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Nest write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m    \u001b[0mtest\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mOptional\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mAnnotated\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrompy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mswan\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcomponents\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTEST\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFieldInfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mannotation\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mNoneType\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrequired\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdescription\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Intermediate write component'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mDocstring:\u001b[0m     \n",
+      "Output group component.\n",
+      "\n",
+      ".. code-block:: text\n",
+      "\n",
+      "    FRAME 'sname' ...\n",
+      "    GROUP 'sname' ...\n",
+      "    CURVE 'sname' ...\n",
+      "    RAY 'rname' ...\n",
+      "    ISOLINE 'sname' 'rname' ...\n",
+      "    POINTS 'sname ...\n",
+      "    NGRID 'sname' ...\n",
+      "    QUANTITY ...\n",
+      "    OUTPUT OPTIONS ...\n",
+      "    BLOCK 'sname' ...\n",
+      "    TABLE 'sname' ...\n",
+      "    SPECOUT 'sname' ...\n",
+      "    NESTOUT 'sname ...\n",
+      "\n",
+      "This group component is used to define multiple types of output locations and\n",
+      "write components in a single model. Only fields that are explicitly prescribed are\n",
+      "rendered by this group component.\n",
+      "\n",
+      "Note\n",
+      "----\n",
+      "The components prescribed are validated according to some constraints as defined\n",
+      "in the SWAN manual:\n",
+      "\n",
+      "- The name `'sname'` of each Locations component must be unique.\n",
+      "- The Locations `'sname'` assigned to each write component must be defined.\n",
+      "- The BLOCK component must be associated with either a `FRAME` or `GROUP`.\n",
+      "- The ISOLINE write component must be associated with a `RAY` component.\n",
+      "- The NGRID and NESTOUT components must be defined together.\n",
+      "\n",
+      "Examples\n",
+      "--------\n",
+      "\n",
+      ".. ipython:: python\n",
+      "    :okwarning:\n",
+      "\n",
+      "    from rompy.swan.components.output import POINTS, BLOCK, QUANTITIES, TABLE\n",
+      "    from rompy.swan.components.group import OUTPUT\n",
+      "    points = POINTS(sname=\"outpts\", xp=[172.3, 172.4], yp=[-39, -39])\n",
+      "    quantity = QUANTITIES(\n",
+      "        quantities=[\n",
+      "            dict(output=[\"depth\", \"hsign\", \"tps\", \"dir\", \"tm01\"], excv=-9),\n",
+      "        ]\n",
+      "    )\n",
+      "    times = dict(tbeg=\"2012-01-01T00:00:00\", delt=\"PT30M\", tfmt=1, dfmt=\"min\")\n",
+      "    block = BLOCK(\n",
+      "        model_type=\"block\",\n",
+      "        sname=\"COMPGRID\",\n",
+      "        fname=\"./swangrid.nc\",\n",
+      "        output=[\"depth\", \"hsign\", \"tps\", \"dir\"],\n",
+      "        times=times,\n",
+      "    )\n",
+      "    table = TABLE(\n",
+      "        sname=\"outpts\",\n",
+      "        format=\"noheader\",\n",
+      "        fname=\"./swantable.nc\",\n",
+      "        output=[\"hsign\", \"hswell\", \"dir\", \"tps\", \"tm01\", \"watlev\", \"qp\"],\n",
+      "        times=times,\n",
+      "    )\n",
+      "    out = OUTPUT(\n",
+      "        points=points,\n",
+      "        quantity=quantity,\n",
+      "        block=block,\n",
+      "        table=table,\n",
+      "    )\n",
+      "    print(out.render())\n",
+      "\u001b[0;31mInit docstring:\u001b[0m\n",
+      "Create a new model by parsing and validating input data from keyword arguments.\n",
+      "\n",
+      "Raises [`ValidationError`][pydantic_core.ValidationError] if the input data cannot be\n",
+      "validated to form a valid model.\n",
+      "\n",
+      "`self` is explicitly positional-only to allow `self` as a field name.\n",
+      "\u001b[0;31mFile:\u001b[0m           /source/csiro/rompy/rompy/swan/components/group.py\n",
+      "\u001b[0;31mType:\u001b[0m           ModelMetaclass\n",
+      "\u001b[0;31mSubclasses:\u001b[0m     "
+     ]
+    }
+   ],
+   "source": [
+    "OUTPUT?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01a41eaa",
+   "metadata": {},
+   "source": [
+    "### BLOCK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5059af97-295d-4348-baf0-845588076c2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BLOCK sname='compgrid' fname='outgrid.nc' LAYOUT idla=3 &\n",
+      "    DEPTH &\n",
+      "    WIND &\n",
+      "    HSIGN &\n",
+      "    HSWELL &\n",
+      "    DIR &\n",
+      "    TPS &\n",
+      "    OUTPUT tbegblk=19700101.000000 deltblk=60.0 MIN\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specifying a single block component\n",
+    "\n",
+    "block = BLOCK(\n",
+    "    sname=\"compgrid\",\n",
+    "    fname=\"outgrid.nc\",\n",
+    "    output=[\"depth\", \"wind\", \"hsign\", \"hswell\", \"dir\", \"tps\"],\n",
+    "    times=TimeRangeOpen(tfmt=1, dfmt=\"min\"),\n",
+    "    idla=3,\n",
+    ")\n",
+    "print(block.render())\n",
+    "\n",
+    "# Note\n",
+    "# ----\n",
+    "# The times field is overriden in the SwanConfig class using the general TimeRange\n",
+    "# but it can be used here to specify the time format and the time delta formats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f5959fe2-5bbb-4944-8b50-effc3bcc8539",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BLOCK sname='compgrid' fname='depth.txt' DEPTH\n",
+      "BLOCK sname='compgrid' fname='hsign.txt' HSIGN\n",
+      "BLOCK sname='compgrid' fname='tps.txt' TPS\n",
+      "BLOCK sname='compgrid' fname='dir.txt' DIR\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specifying multiple block components\n",
+    "\n",
+    "block1 = BLOCK(sname=\"compgrid\", fname=\"depth.txt\", output=[\"depth\"])\n",
+    "block2 = BLOCK(sname=\"compgrid\", fname=\"hsign.txt\", output=[\"hsign\"])\n",
+    "block3 = BLOCK(sname=\"compgrid\", fname=\"tps.txt\", output=[\"tps\"])\n",
+    "block4 = BLOCK(sname=\"compgrid\", fname=\"dir.txt\", output=[\"dir\"])\n",
+    "\n",
+    "blocks = BLOCKS(components=[block1, block2, block3, block4])\n",
+    "print(blocks.render())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rompy-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rompy/swan/components/base.py
+++ b/rompy/swan/components/base.py
@@ -115,3 +115,15 @@ class BaseComponent(RompyBaseModel):
             cmd_lines = [cmd_lines]
         cmd_lines = [self._render_split_cmd(cmd_line) for cmd_line in cmd_lines]
         return "\n".join(cmd_lines)
+
+
+class MultiComponents(BaseComponent):
+    """Mixin for components that can have multiple components."""
+
+    components: list = Field(description="The components to render")
+
+    def cmd(self) -> list[str]:
+        repr = []
+        for component in self.components:
+            repr += [component.cmd()]
+        return repr

--- a/rompy/swan/components/group.py
+++ b/rompy/swan/components/group.py
@@ -67,6 +67,7 @@ from rompy.swan.components.output import (
     QUANTITIES,
     OUTPUT_OPTIONS,
     BLOCK,
+    BLOCKS,
     TABLE,
     SPECOUT,
     NESTOUT,
@@ -440,11 +441,14 @@ RAY_TYPE = Annotated[RAY, Field(description="Ray locations component")]
 ISOLINE_TYPE = Annotated[ISOLINE, Field(description="Isoline locations component")]
 QUANTITY_TYPE = Annotated[QUANTITIES, Field(description="Quantity component")]
 OUTOPT_TYPE = Annotated[OUTPUT_OPTIONS, Field(description="Output options component")]
-BLOCK_TYPE = Annotated[BLOCK, Field(description="Block write component")]
 TABLE_TYPE = Annotated[TABLE, Field(description="Table write component")]
 SPECOUT_TYPE = Annotated[SPECOUT, Field(description="Spectra write component")]
 NESTOUT_TYPE = Annotated[NESTOUT, Field(description="Nest write component")]
 TEST_TYPE = Annotated[TEST, Field(description="Intermediate write component")]
+BLOCK_TYPE = Annotated[
+    Union[BLOCK, BLOCKS],
+    Field(description="Block write component", discriminator="model_type"),
+]
 POINTS_TYPE = Annotated[
     Union[POINTS, POINTS_FILE],
     Field(description="Points locations component", discriminator="model_type"),

--- a/rompy/swan/components/group.py
+++ b/rompy/swan/components/group.py
@@ -559,16 +559,17 @@ class OUTPUT(BaseGroupComponent):
             obj = getattr(self, write)
             if obj is None:
                 continue
-            sname = obj.sname
-            if sname in SPECIAL_NAMES:
-                return self
-            try:
-                self._filter_location(sname)
-            except ValueError as err:
-                raise ValueError(
-                    f"Write component '{write}' specified with sname='{sname}' but no "
-                    f"location component with sname='{sname}' has been defined"
-                ) from err
+            snames = obj.sname if isinstance(obj.sname, list) else [obj.sname]
+            for sname in snames:
+                if sname in SPECIAL_NAMES:
+                    return self
+                try:
+                    self._filter_location(sname)
+                except ValueError as err:
+                    raise ValueError(
+                        f"Write component '{write}' specified with sname='{sname}' but "
+                        f"no location component with sname='{sname}' has been defined"
+                    ) from err
         return self
 
     @model_validator(mode="after")
@@ -587,16 +588,19 @@ class OUTPUT(BaseGroupComponent):
     def block_with_frame_or_group(self) -> "OUTPUT":
         """Ensure Block is only defined for FRAME or GROUP locations."""
         if self.block is not None:
-            sname = self.block.sname
-            if sname in ["BOTTGRID", "COMPGRID"]:
-                return self
-            location = self._filter_location(sname)
-            component = location.model_type.upper().split("_")[0]
-            if component not in ["FRAME", "GROUP"]:
-                raise ValueError(
-                    f"Block sname='{sname}' specified with {component} Location "
-                    "component but only only FRAME or GROUP components are supported"
-                )
+            snames = self.block.sname
+            if isinstance(snames, str):
+                snames = [self.block.sname]
+            for sname in snames:
+                if sname not in ["BOTTGRID", "COMPGRID"]:
+                    location = self._filter_location(sname)
+                    component = location.model_type.upper().split("_")[0]
+                    if component not in ["FRAME", "GROUP"]:
+                        raise ValueError(
+                            f"Block sname='{sname}' specified with {component} "
+                            "location component but only only FRAME or GROUP "
+                            "components are supported"
+                        )
         return self
 
     @model_validator(mode="after")
@@ -664,7 +668,7 @@ class OUTPUT(BaseGroupComponent):
             obj = getattr(self, field)
             if obj is None:
                 continue
-            obj_snames = obj.sname if isinstance(obj.sname, list) else [obj.sname]
+            obj_snames = obj.sname
             for obj_sname in obj_snames:
                 if obj_sname == sname:
                     return obj
@@ -678,7 +682,8 @@ class OUTPUT(BaseGroupComponent):
         if self.group is not None:
             repr += [f"{self.group.cmd()}"]
         if self.curve is not None:
-            repr += self.curve.cmd()  # Component renders a list
+            # Component renders a list
+            repr += self.curve.cmd()
         if self.ray is not None:
             repr += [f"{self.ray.cmd()}"]
         if self.isoline is not None:
@@ -688,11 +693,17 @@ class OUTPUT(BaseGroupComponent):
         if self.ngrid is not None:
             repr += [f"{self.ngrid.cmd()}"]
         if self.quantity is not None:
-            repr += self.quantity.cmd()  # Component renders a list
+            # Component renders a list
+            repr += self.quantity.cmd()
         if self.output_options is not None:
             repr += [f"{self.output_options.cmd()}"]
         if self.block is not None:
-            repr += [f"{self.block.cmd()}"]
+            # Component may or may not render a list, handles both
+            cmds = self.block.cmd()
+            if not isinstance(cmds, list):
+                cmds = [cmds]
+            for cmd in cmds:
+                repr += [f"{cmd}"]
         if self.table is not None:
             repr += [f"{self.table.cmd()}"]
         if self.specout is not None:

--- a/rompy/swan/components/output.py
+++ b/rompy/swan/components/output.py
@@ -1127,12 +1127,14 @@ class BaseWrite(BaseComponent, ABC):
     @model_validator(mode="after")
     def validate_special_names(self) -> "BaseWrite":
         special_names = ("COMPGRID", "BOTTGRID")
-        if self.sname in special_names and self.model_type.upper() != "BLOCK":
-            raise ValueError(f"Special name {self.sname} is only supported with BLOCK")
+        snames = self.sname if isinstance(self.sname, list) else [self.sname]
+        for sname in snames:
+            if sname in special_names and self.model_type.upper() != "BLOCK":
+                raise ValueError(f"Special name {sname} is only supported with BLOCK")
         return self
 
     @model_validator(mode="after")
-    def validate_times(self) -> "BLOCK":
+    def validate_times(self) -> "BaseWrite":
         if self.times is not None:
             self.times.suffix = self.suffix
         return self
@@ -1306,6 +1308,10 @@ class BLOCKS(MultiComponents):
         default="blocks", description="Model type discriminator"
     )
     components: list[BLOCK] = Field(description="BLOCK components")
+
+    @property
+    def sname(self) -> list[str]:
+        return [component.sname for component in self.components]
 
 
 class TABLE(BaseWrite):

--- a/rompy/swan/components/output.py
+++ b/rompy/swan/components/output.py
@@ -5,7 +5,7 @@ from abc import ABC
 from pydantic import field_validator, model_validator, Field
 
 from rompy.swan.types import BlockOptions, IDLA
-from rompy.swan.components.base import BaseComponent
+from rompy.swan.components.base import BaseComponent, MultiComponents
 from rompy.swan.subcomponents.base import XY, IJ
 from rompy.swan.subcomponents.readgrid import GRIDREGULAR
 from rompy.swan.subcomponents.time import TimeRangeOpen
@@ -1273,6 +1273,39 @@ class BLOCK(BaseWrite):
         if self.times is not None:
             repr += f"\nOUTPUT {self.times.render()}"
         return repr
+
+
+class BLOCKS(MultiComponents):
+    """Write multiple spatial distributions.
+
+    .. code-block:: text
+
+        BLOCK 'sname' ->HEADER|NOHEADER 'fname1' (LAYOUT [idla]) < output > &
+            [unit] (OUTPUT [tbegblk] [deltblk]) SEC|MIN|HR|DAY
+        BLOCK 'sname' ->HEADER|NOHEADER 'fname2' (LAYOUT [idla]) < output > &
+            [unit] (OUTPUT [tbegblk] [deltblk]) SEC|MIN|HR|DAY
+        ..
+
+    This component can be used to prescribe and render multiple BLOCK components.
+
+    Examples
+    --------
+
+    .. ipython:: python
+        :okwarning:
+
+        from rompy.swan.components.output import BLOCK, BLOCKS
+        block1 = BLOCK(sname="outgrid", fname="./depth.txt", output=["depth"])
+        block2 = BLOCK(sname="outgrid", fname="./output.nc", output=["hsign", "hswell"])
+        blocks = BLOCKS(components=[block1, block2])
+        print(blocks.render())
+
+    """
+
+    model_type: Literal["blocks"] = Field(
+        default="blocks", description="Model type discriminator"
+    )
+    components: list[BLOCK] = Field(description="BLOCK components")
 
 
 class TABLE(BaseWrite):

--- a/tests/swan/components/test_output.py
+++ b/tests/swan/components/test_output.py
@@ -23,6 +23,7 @@ from rompy.swan.components.output import (
     QUANTITIES,
     OUTPUT_OPTIONS,
     BLOCK,
+    BLOCKS,
     TABLE,
     SPECOUT,
     NESTOUT,
@@ -267,6 +268,18 @@ def test_output_options(output_options):
 def test_block():
     block = BLOCK(sname="outgrid", fname="./depth-frame.nc", output=["depth"])
     block.render() == "BLOCK sname='outgrid' fname='./depth-frame.nc' DEPTH"
+
+
+def test_blocks():
+    block1 = BLOCK(sname="outgrid", fname="./depth.txt", output=["depth"])
+    block2 = BLOCK(
+        sname="outgrid",
+        fname="./output.nc",
+        output=["hsign", "hswell", "tm01", "tps", "vel", "wind"],
+    )
+    blocks = BLOCKS(components=[block1, block2])
+    assert len(blocks.components) == 2
+    assert isinstance(blocks.components[0], BLOCK)
 
 
 def test_block_nonstationary(block):


### PR DESCRIPTION
New framework to define MultiComponent types from existing components.

A [MultiComponents](https://github.com/rom-py/rompy/blob/multi-components/rompy/swan/components/base.py#L120) base class has been implemented to convert existing components into a list of their own types which can be used to render more than one instance of that command.

A new [BLOCKS](https://github.com/rom-py/rompy/blob/multi-components/rompy/swan/components/output.py#L1278) components has been implemented using that approach.

Other components have been implemented before to provide a similar ability of replicating SWAN commands, for example the [QUANTITIES](https://github.com/rom-py/rompy/blob/multi-components/rompy/swan/components/output.py#L946) component. These existing classes should now be rewritten to use this new Base Class approach (this still needs to be done). There will be a small change from the user's perspective in that the main field for them will always  be `components` now, which is different from the existing ones which use custom fields for each class (for example, in the case of QUANTITIES, the field is called [quantities](https://github.com/rom-py/rompy/blob/multi-components/rompy/swan/components/output.py#L978), for the CURVES component the field is currently defined as [curves](https://github.com/rom-py/rompy/blob/multi-components/rompy/swan/components/output.py#L315), and so on).

This pull request should address https://github.com/rom-py/rompy/issues/118 from @alsonathif