### PR TITLE
Forbid extra

### DIFF
--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -12,7 +12,7 @@ from pydantic import (
 
 class RompyBaseModel(BaseModel):
     # The config below prevents https://github.com/pydantic/pydantic/discussions/7121
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), extra="forbid")
 
 
 class Latitude(BaseModel):

--- a/rompy/core/types.py
+++ b/rompy/core/types.py
@@ -312,6 +312,7 @@ class DatasetCoords(RompyBaseModel):
     x: Optional[str] = Field("longitude", description="Name of the x coordinate")
     y: Optional[str] = Field("latitude", description="Name of the y coordinate")
     z: Optional[str] = Field("depth", description="Name of the z coordinate")
+    s: Optional[str] = Field("site", description="Name of the site coordinate")
 
 
 class Slice(BaseModel):

--- a/rompy/schism/data.py
+++ b/rompy/schism/data.py
@@ -13,8 +13,6 @@ from pyschism.forcing.bctides import Bctides
 from rompy.core import DataGrid, RompyBaseModel
 from rompy.core.boundary import BoundaryWaveStation, DataBoundary
 from rompy.core.data import DataBlob
-from rompy.core.boundary import BoundaryWaveStation, DataBoundary
-from rompy.core.data import DataBlob
 from rompy.core.time import TimeRange
 from rompy.schism.grid import SCHISMGrid
 from rompy.utils import total_seconds
@@ -56,7 +54,8 @@ class SfluxSource(DataGrid):
 
     @property
     def namelist(self) -> dict:
-        ret = self.model_dump()
+        # ret = self.model_dump()
+        ret = {}
         for key, value in self.model_dump().items():
             if key in ["relative_weight", "max_window_hours", "fail_if_missing"]:
                 ret.update({f"{self.id}_{key}": value})
@@ -203,12 +202,24 @@ class SCHISMDataSflux(RompyBaseModel):
         default="sflux",
         description="Model type discriminator",
     )
-    air_1: Union[DataBlob, SfluxAir, None] = Field(None, description="sflux air source 1")
-    air_2: Union[DataBlob, SfluxAir, None] = Field(None, description="sflux air source 2")
-    rad_1: Union[DataBlob, SfluxRad, None] = Field(None, description="sflux rad source 1")
-    rad_2: Union[DataBlob, SfluxRad, None] = Field(None, description="sflux rad source 2")
-    prc_1: Union[DataBlob, SfluxPrc, None] = Field(None, description="sflux prc source 1")
-    prc_2: Union[DataBlob, SfluxPrc, None] = Field(None, description="sflux prc source 2")
+    air_1: Union[DataBlob, SfluxAir, None] = Field(
+        None, description="sflux air source 1"
+    )
+    air_2: Union[DataBlob, SfluxAir, None] = Field(
+        None, description="sflux air source 2"
+    )
+    rad_1: Union[DataBlob, SfluxRad, None] = Field(
+        None, description="sflux rad source 1"
+    )
+    rad_2: Union[DataBlob, SfluxRad, None] = Field(
+        None, description="sflux rad source 2"
+    )
+    prc_1: Union[DataBlob, SfluxPrc, None] = Field(
+        None, description="sflux prc source 1"
+    )
+    prc_2: Union[DataBlob, SfluxPrc, None] = Field(
+        None, description="sflux prc source 2"
+    )
 
     def get(
         self,
@@ -667,8 +678,12 @@ class SCHISMData(RompyBaseModel):
     )
     atmos: Optional[SCHISMDataSflux] = Field(None, description="atmospheric data")
     ocean: Optional[SCHISMDataOcean] = Field(None, description="ocean data")
-    wave: Optional[Union[DataBlob, SCHISMDataWave]] = Field(None, description="wave data")
-    tides: Optional[Union[DataBlob, SCHISMDataTides]] = Field(None, description="tidal data")
+    wave: Optional[Union[DataBlob, SCHISMDataWave]] = Field(
+        None, description="wave data"
+    )
+    tides: Optional[Union[DataBlob, SCHISMDataTides]] = Field(
+        None, description="tidal data"
+    )
 
     def get(
         self,

--- a/rompy/swan/data.py
+++ b/rompy/swan/data.py
@@ -210,7 +210,7 @@ class Swan_accessor(object):
 
         """
         return SwanGrid(
-            gridtype="REG",
+            grid_type="REG",
             x0=float(self._obj[x].min()),
             y0=float(self._obj[y].min()),
             dx=float(np.diff(self._obj[x]).mean()),

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -42,7 +42,6 @@ def test_custom_template(tmpdir):
     runtime = ModelRun(
         run_id="test_base",
         output_dir=str(tmpdir),
-        template="simple_templates/base",
         config=config,
     )
     runtime.generate()


### PR DESCRIPTION
Forbid extra arguments in the rompy base model.

By default, pydantic ignores extra arguments (i.e., not defined in the class as a field) when we instantiate a model. This can be a bit dangerous / misleading. For example, if you make a typo in one of the parameter names when instantiating, the wrong argument will be ignored and you won't be setting the value for the expected field.

This pull request proposes to change the behaviour to "forbid". This way, extra arguments will be explicitly forbid and result in an exception raised.

This change resulted in some broken tests that were using extra fields (either because of a typo or because the class changed and the test was not updated). I have fixed them, except for the schism one - @tomdurrant if you could have a look at that one please that would be great.