### PR TITLE
Data timeseries

### DIFF
--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -300,3 +300,196 @@ class DataGrid(DataBlob):
         outfile = Path(destdir) / self.outfile
         self.ds.to_netcdf(outfile)
         return outfile
+
+
+from rompy.core.source import SourceTimeseriesCSV, SourceTimeseriesDataFrame
+
+
+class DataTimeseries(DataBlob):
+    """Timeseries Data object for model ingestion.
+
+    Generic timeseries data object for datasets that need to be filtered and written to
+    netcdf.
+
+    """
+
+    model_type: Literal["timeseries"] = Field(
+        default="timeseries",
+        description="Model type discriminator",
+    )
+    source: Union[SourceTimeseriesCSV, SourceTimeseriesDataFrame] = Field(
+        description="Source reader, must return an xarray timeseries dataset in the open method",
+        discriminator="model_type",
+    )
+    filter: Optional[Filter] = Field(
+        default_factory=Filter,
+        description="Optional filter specification to apply to the dataset",
+    )
+    variables: Optional[list[str]] = Field(
+        [], description="Subset of variables to extract from the dataset"
+    )
+    coords: Optional[DatasetCoords] = Field(
+        default=DatasetCoords(),
+        description="Names of the coordinates in the dataset",
+    )
+    crop_data: bool = Field(
+        default=True,
+        description=(
+            "Update crop filters from Grid and Time objects if passed to get method"
+        ),
+    )
+    buffer: float = Field(
+        default=0.0,
+        description="Space to buffer the grid bounding box if `filter_grid` is True",
+    )
+    time_buffer: list[int] = Field(
+        default=[0, 0],
+        description=(
+            "Number of source data timesteps to buffer the time range "
+            "if `filter_time` is True"
+        ),
+    )
+
+    def _filter_grid(self, grid: GRID_TYPES):
+        """Define the filters to use to extract data to this grid"""
+        x0, y0, x1, y1 = grid.bbox(buffer=self.buffer)
+        self.filter.crop.update(
+            {
+                self.coords.x: Slice(start=x0, stop=x1),
+                self.coords.y: Slice(start=y0, stop=y1),
+            }
+        )
+
+    def _filter_time(self, time: TimeRange, end_buffer=1):
+        """Define the filters to use to extract data to this grid"""
+        start = time.start
+        end = time.end
+        t = self.coords.t
+        if t in self.source.coordinates and self.source.coordinates[t].size > 1:
+            times = self.source.coordinates[t].to_index().to_pydatetime()
+            dt = times[1] - times[0]
+            if self.time_buffer[0]:
+                start -= dt * self.time_buffer[0]
+            if self.time_buffer[1]:
+                end += dt * self.time_buffer[1]
+        self.filter.crop.update({t: Slice(start=start, stop=end)})
+
+    @property
+    def ds(self):
+        """Return the xarray dataset for this data source."""
+        ds = self.source.open(
+            variables=self.variables, filters=self.filter, coords=self.coords
+        )
+        return ds
+
+    def _figsize(self, x0, x1, y0, y1, fscale):
+        xlen = abs(x1 - x0)
+        ylen = abs(y1 - y0)
+        if xlen >= ylen:
+            figsize = (fscale, (fscale * ylen / xlen or fscale) * 0.8)
+        else:
+            figsize = ((fscale * xlen / ylen) * 1.2 or fscale, fscale)
+        return figsize
+
+    def plot(
+        self,
+        param,
+        isel={},
+        model_grid=None,
+        cmap="turbo",
+        figsize=None,
+        fscale=10,
+        borders=True,
+        land=True,
+        coastline=True,
+        **kwargs,
+    ):
+        """Plot the grid."""
+
+        projection = ccrs.PlateCarree()
+        transform = ccrs.PlateCarree()
+
+        # Sanity checks
+        try:
+            ds = self.ds[param].isel(isel)
+        except KeyError as err:
+            raise ValueError(f"Parameter {param} not in dataset") from err
+
+        if ds[self.coords.x].size <= 1:
+            raise ValueError(f"Cannot plot {param} with only one x coordinate\n\n{ds}")
+        if ds[self.coords.y].size <= 1:
+            raise ValueError(f"Cannot plot {param} with only one y coordinate\n\n{ds}")
+
+        # Set some plot parameters:
+        x0 = ds[self.coords.x].values[0]
+        y0 = ds[self.coords.y].values[0]
+        x1 = ds[self.coords.x].values[-1]
+        y1 = ds[self.coords.y].values[-1]
+
+        # create figure and plot/map
+        if figsize is None:
+            figsize = self._figsize(x0, x1, y0, y1, fscale)
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(111, projection=projection)
+
+        ds.plot.pcolormesh(ax=ax, cmap=cmap, **kwargs)
+
+        if borders:
+            ax.add_feature(cfeature.BORDERS)
+        if land:
+            ax.add_feature(cfeature.LAND, zorder=1)
+        if coastline:
+            ax.add_feature(cfeature.COASTLINE)
+
+        ax.gridlines(
+            crs=transform,
+            draw_labels=["left", "bottom"],
+            linewidth=1,
+            color="gray",
+            alpha=0.5,
+            linestyle="--",
+        )
+
+        # Plot the model domain
+        if model_grid:
+            bx, by = model_grid.boundary_points()
+            poly = plt.Polygon(list(zip(bx, by)), facecolor="r", alpha=0.05)
+            ax.add_patch(poly)
+            ax.plot(bx, by, lw=2, color="k")
+        return fig, ax
+
+    @property
+    def outfile(self) -> str:
+        return f"{self.id}.nc"
+
+    def get(
+        self,
+        destdir: str | Path,
+        grid: Optional[GRID_TYPES] = None,
+        time: Optional[TimeRange] = None,
+    ) -> Path:
+        """Write the data source to a new location.
+
+        Parameters
+        ----------
+        destdir : str | Path
+            The destination directory to write the netcdf data to.
+        grid: GRID_TYPES, optional
+            The grid to filter the data to, only used if `self.crop_data` is True.
+        time: TimeRange, optional
+            The times to filter the data to, only used if `self.crop_data` is True.
+
+        Returns
+        -------
+        outfile: Path
+            The path to the written file.
+
+        """
+        if self.crop_data:
+            if grid is not None:
+                self._filter_grid(grid)
+            if time is not None:
+                self._filter_time(time)
+        outfile = Path(destdir) / self.outfile
+        self.ds.to_netcdf(outfile)
+        return outfile

--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -104,212 +104,16 @@ GRID_TYPES = Union[BaseGrid, RegularGrid]
 SOURCE_TYPES = tuple([eps.load() for eps in entry_points(group="rompy.source")])
 
 
-class DataGrid(DataBlob):
-    """Data object for model ingestion.
-
-    Generic data object for xarray datasets that need to be filtered and written to
-    netcdf.
-
-    Note
-    ----
-    The fields `filter_grid` and `filter_time` trigger updates to the crop filter from
-    the grid and time range objects passed to the get method. This is useful for data
-    sources that are not defined on the same grid as the model grid or the same time
-    range as the model run.
-
-    """
-
-    model_type: Literal["data_grid"] = Field(
-        default="data_grid",
-        description="Model type discriminator",
-    )
-    source: Union[SOURCE_TYPES] = Field(
-        description="Source reader, must return an xarray dataset in the open method",
-        discriminator="model_type",
-    )
-
-    filter: Optional[Filter] = Field(
-        default_factory=Filter,
-        description="Optional filter specification to apply to the dataset",
-    )
-    variables: Optional[list[str]] = Field(
-        [], description="Subset of variables to extract from the dataset"
-    )
-    coords: Optional[DatasetCoords] = Field(
-        default=DatasetCoords(),
-        description="Names of the coordinates in the dataset",
-    )
-    crop_data: bool = Field(
-        default=True,
-        description=(
-            "Update crop filters from Grid and Time objects if passed to get method"
-        ),
-    )
-    buffer: float = Field(
-        default=0.0,
-        description="Space to buffer the grid bounding box if `filter_grid` is True",
-    )
-    time_buffer: list[int] = Field(
-        default=[0, 0],
-        description=(
-            "Number of source data timesteps to buffer the time range "
-            "if `filter_time` is True"
-        ),
-    )
-
-    def _filter_grid(self, grid: GRID_TYPES):
-        """Define the filters to use to extract data to this grid"""
-        x0, y0, x1, y1 = grid.bbox(buffer=self.buffer)
-        self.filter.crop.update(
-            {
-                self.coords.x: Slice(start=x0, stop=x1),
-                self.coords.y: Slice(start=y0, stop=y1),
-            }
-        )
-
-    def _filter_time(self, time: TimeRange, end_buffer=1):
-        """Define the filters to use to extract data to this grid"""
-        start = time.start
-        end = time.end
-        t = self.coords.t
-        if t in self.source.coordinates and self.source.coordinates[t].size > 1:
-            times = self.source.coordinates[t].to_index().to_pydatetime()
-            dt = times[1] - times[0]
-            if self.time_buffer[0]:
-                start -= dt * self.time_buffer[0]
-            if self.time_buffer[1]:
-                end += dt * self.time_buffer[1]
-        self.filter.crop.update({t: Slice(start=start, stop=end)})
-
-    @property
-    def ds(self):
-        """Return the xarray dataset for this data source."""
-        ds = self.source.open(
-            variables=self.variables, filters=self.filter, coords=self.coords
-        )
-        return ds
-
-    def _figsize(self, x0, x1, y0, y1, fscale):
-        xlen = abs(x1 - x0)
-        ylen = abs(y1 - y0)
-        if xlen >= ylen:
-            figsize = (fscale, (fscale * ylen / xlen or fscale) * 0.8)
-        else:
-            figsize = ((fscale * xlen / ylen) * 1.2 or fscale, fscale)
-        return figsize
-
-    def plot(
-        self,
-        param,
-        isel={},
-        model_grid=None,
-        cmap="turbo",
-        figsize=None,
-        fscale=10,
-        borders=True,
-        land=True,
-        coastline=True,
-        **kwargs,
-    ):
-        """Plot the grid."""
-
-        projection = ccrs.PlateCarree()
-        transform = ccrs.PlateCarree()
-
-        # Sanity checks
-        try:
-            ds = self.ds[param].isel(isel)
-        except KeyError as err:
-            raise ValueError(f"Parameter {param} not in dataset") from err
-
-        if ds[self.coords.x].size <= 1:
-            raise ValueError(f"Cannot plot {param} with only one x coordinate\n\n{ds}")
-        if ds[self.coords.y].size <= 1:
-            raise ValueError(f"Cannot plot {param} with only one y coordinate\n\n{ds}")
-
-        # Set some plot parameters:
-        x0 = ds[self.coords.x].values[0]
-        y0 = ds[self.coords.y].values[0]
-        x1 = ds[self.coords.x].values[-1]
-        y1 = ds[self.coords.y].values[-1]
-
-        # create figure and plot/map
-        if figsize is None:
-            figsize = self._figsize(x0, x1, y0, y1, fscale)
-        fig = plt.figure(figsize=figsize)
-        ax = fig.add_subplot(111, projection=projection)
-
-        ds.plot.pcolormesh(ax=ax, cmap=cmap, **kwargs)
-
-        if borders:
-            ax.add_feature(cfeature.BORDERS)
-        if land:
-            ax.add_feature(cfeature.LAND, zorder=1)
-        if coastline:
-            ax.add_feature(cfeature.COASTLINE)
-
-        ax.gridlines(
-            crs=transform,
-            draw_labels=["left", "bottom"],
-            linewidth=1,
-            color="gray",
-            alpha=0.5,
-            linestyle="--",
-        )
-
-        # Plot the model domain
-        if model_grid:
-            bx, by = model_grid.boundary_points()
-            poly = plt.Polygon(list(zip(bx, by)), facecolor="r", alpha=0.05)
-            ax.add_patch(poly)
-            ax.plot(bx, by, lw=2, color="k")
-        return fig, ax
-
-    @property
-    def outfile(self) -> str:
-        return f"{self.id}.nc"
-
-    def get(
-        self,
-        destdir: str | Path,
-        grid: Optional[GRID_TYPES] = None,
-        time: Optional[TimeRange] = None,
-    ) -> Path:
-        """Write the data source to a new location.
-
-        Parameters
-        ----------
-        destdir : str | Path
-            The destination directory to write the netcdf data to.
-        grid: GRID_TYPES, optional
-            The grid to filter the data to, only used if `self.crop_data` is True.
-        time: TimeRange, optional
-            The times to filter the data to, only used if `self.crop_data` is True.
-
-        Returns
-        -------
-        outfile: Path
-            The path to the written file.
-
-        """
-        if self.crop_data:
-            if grid is not None:
-                self._filter_grid(grid)
-            if time is not None:
-                self._filter_time(time)
-        outfile = Path(destdir) / self.outfile
-        self.ds.to_netcdf(outfile)
-        return outfile
-
-
+# Just here temporarily. We need to decide how to handle different types of sources
+# that are used with different types of data objects in the entry points.
 from rompy.core.source import SourceTimeseriesCSV, SourceTimeseriesDataFrame
 
 
 class DataTimeseries(DataBlob):
-    """Timeseries Data object for model ingestion.
+    """Data object for timeseries source data.
 
-    Generic timeseries data object for datasets that need to be filtered and written to
-    netcdf.
+    Generic data object for xarray datasets that only have time as a dimension and do
+    not need to be cropped to a specific grid.
 
     """
 
@@ -351,14 +155,8 @@ class DataTimeseries(DataBlob):
     )
 
     def _filter_grid(self, grid: GRID_TYPES):
-        """Define the filters to use to extract data to this grid"""
-        x0, y0, x1, y1 = grid.bbox(buffer=self.buffer)
-        self.filter.crop.update(
-            {
-                self.coords.x: Slice(start=x0, stop=x1),
-                self.coords.y: Slice(start=y0, stop=y1),
-            }
-        )
+        """No spatial selection is required for timeseries data."""
+        pass
 
     def _filter_time(self, time: TimeRange, end_buffer=1):
         """Define the filters to use to extract data to this grid"""
@@ -381,6 +179,72 @@ class DataTimeseries(DataBlob):
             variables=self.variables, filters=self.filter, coords=self.coords
         )
         return ds
+
+    @property
+    def outfile(self) -> str:
+        return f"{self.id}.nc"
+
+    def get(
+        self,
+        destdir: str | Path,
+        grid: Optional[GRID_TYPES] = None,
+        time: Optional[TimeRange] = None,
+    ) -> Path:
+        """Write the data source to a new location.
+
+        Parameters
+        ----------
+        destdir : str | Path
+            The destination directory to write the netcdf data to.
+        grid: GRID_TYPES, optional
+            The grid to filter the data to, only used if `self.crop_data` is True.
+        time: TimeRange, optional
+            The times to filter the data to, only used if `self.crop_data` is True.
+
+        Returns
+        -------
+        outfile: Path
+            The path to the written file.
+
+        """
+        if self.crop_data:
+            if grid is not None:
+                self._filter_grid(grid)
+            if time is not None:
+                self._filter_time(time)
+        outfile = Path(destdir) / self.outfile
+        self.ds.to_netcdf(outfile)
+        return outfile
+
+
+class DataGrid(DataTimeseries):
+    """Data object for gridded source data.
+
+    Generic data object for xarray datasets that with gridded spatial dimensions
+
+    Note
+    ----
+    The fields `filter_grid` and `filter_time` trigger updates to the crop filter from
+    the grid and time range objects passed to the get method. This is useful for data
+    sources that are not defined on the same grid as the model grid or the same time
+    range as the model run.
+
+    """
+
+    model_type: Literal["grid"] = Field(
+        default="grid",
+        description="Model type discriminator",
+    )
+
+    def _filter_grid(self, grid: GRID_TYPES):
+        """Define the filters to use to extract data to this grid"""
+        x0, y0, x1, y1 = grid.bbox(buffer=self.buffer)
+        self.filter.crop.update(
+            {
+                self.coords.x: Slice(start=x0, stop=x1),
+                self.coords.y: Slice(start=y0, stop=y1),
+            }
+        )
 
     def _figsize(self, x0, x1, y0, y1, fscale):
         xlen = abs(x1 - x0)
@@ -457,39 +321,3 @@ class DataTimeseries(DataBlob):
             ax.add_patch(poly)
             ax.plot(bx, by, lw=2, color="k")
         return fig, ax
-
-    @property
-    def outfile(self) -> str:
-        return f"{self.id}.nc"
-
-    def get(
-        self,
-        destdir: str | Path,
-        grid: Optional[GRID_TYPES] = None,
-        time: Optional[TimeRange] = None,
-    ) -> Path:
-        """Write the data source to a new location.
-
-        Parameters
-        ----------
-        destdir : str | Path
-            The destination directory to write the netcdf data to.
-        grid: GRID_TYPES, optional
-            The grid to filter the data to, only used if `self.crop_data` is True.
-        time: TimeRange, optional
-            The times to filter the data to, only used if `self.crop_data` is True.
-
-        Returns
-        -------
-        outfile: Path
-            The path to the written file.
-
-        """
-        if self.crop_data:
-            if grid is not None:
-                self._filter_grid(grid)
-            if time is not None:
-                self._filter_time(time)
-        outfile = Path(destdir) / self.outfile
-        self.ds.to_netcdf(outfile)
-        return outfile

--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -235,6 +235,10 @@ class DataGrid(DataTimeseries):
         default="grid",
         description="Model type discriminator",
     )
+    source: Union[SOURCE_TYPES] = Field(
+        description="Source reader, must return an xarray gridded dataset in the open method",
+        discriminator="model_type",
+    )
 
     def _filter_grid(self, grid: GRID_TYPES):
         """Define the filters to use to extract data to this grid"""

--- a/rompy/core/source.py
+++ b/rompy/core/source.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 
 import fsspec
 import intake
+import pandas as pd
 import xarray as xr
 import wavespectra
 from intake.catalog import Catalog
@@ -267,3 +268,66 @@ class SourceWavespectra(SourceBase):
 
     def _open(self):
         return getattr(wavespectra, self.reader)(self.uri, **self.kwargs)
+
+
+class SourceTimeseriesCSV(SourceBase):
+    """Timeseries source class from CSV file.
+
+    This class should return a timeseries from a CSV file. The dataset variables are
+    defined from the column headers, therefore the appropriate read_csv kwargs must be
+    passed to allow defining the columns. The time index is defined from column name
+    identified by the tcol field.
+
+    """
+
+    model_type: Literal["csv"] = Field(
+        default="csv",
+        description="Model type discriminator",
+    )
+    filename: str | Path = Field(description="Path to the csv file")
+    tcol: str = Field(
+        default="time",
+        description="Name of the column containing the time data",
+    )
+    read_csv_kwargs: dict = Field(
+        default={},
+        description="Keyword arguments to pass to pandas.read_csv",
+    )
+
+    @model_validator(mode="after")
+    def validate_kwargs(self) -> "SourceTimeseriesCSV":
+        """Validate the keyword arguments."""
+        if "parse_dates" not in self.read_csv_kwargs:
+            self.read_csv_kwargs["parse_dates"] = [self.tcol]
+        if "index_col" not in self.read_csv_kwargs:
+            self.read_csv_kwargs["index_col"] = self.tcol
+        return self
+
+    def _open_dataframe(self) -> pd.DataFrame:
+        """Read the data from the csv file."""
+        return pd.read_csv(self.filename, **self.read_csv_kwargs)
+
+    def _open(self) -> xr.Dataset:
+        """Interpolate the xyz data onto a regular grid."""
+        df = self._open_dataframe()
+        ds = xr.Dataset.from_dataframe(df).rename({self.tcol: "time"})
+        return ds
+
+
+class SourceTimeseriesDataFrame(SourceBase):
+    """Source dataset from an existing pandas DataFrame timeseries object."""
+
+    model_type: Literal["dataframe"] = Field(
+        default="dataframe",
+        description="Model type discriminator",
+    )
+    obj: pd.DataFrame = Field(
+        description="pandas DataFrame object",
+    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __str__(self) -> str:
+        return f"SourceTimeseriesDataFrame(obj={self.obj})"
+
+    def _open(self) -> xr.Dataset:
+        return xr.Dataset.from_dataframe(self.obj).rename({self.obj.index.name: "time"})


### PR DESCRIPTION
This pull request adds a new core [data class](https://github.com/rom-py/rompy/blob/data-timeseries/rompy/core/data.py#L112) for timeseries-type sources which do not have a spatial grid and do not need to be spatially selected. The use case is for example a small coastal domain over which there is no significant spatial variability in the forcing data so it can be prescribed by a simple timeseries instead of a gridded source.

This new `DataTimeseries` was defined as a base class for `DataGrid`, but with different source types accepted in the `source` field, and a `_filter_grid` method that does not do anything since there is no grid to be filtered. The source types currently available for this class are:

- [SourceTimeseriesCSV](https://github.com/rom-py/rompy/blob/data-timeseries/rompy/core/source.py#L273) (analogous to [SourceFile](https://github.com/rom-py/rompy/blob/data-timeseries/rompy/core/source.py#L86), but deals with a csv type file that is read with pandas rather than xarray)
- [SourceTimeseriesDataFrame](https://github.com/rom-py/rompy/blob/data-timeseries/rompy/core/source.py#L317) (analogous to [SourceDataset](https://github.com/rom-py/rompy/blob/data-timeseries/rompy/core/source.py#L67) but accepts a DataFrame object instead of a Dataset).

If we are happy with this approach, one remaining question is how to define the sources in the entry points. The source types for grids and timeseries data objects are different, so these sources cannot be installed in the same entry point group, as these are all loaded and used to define the source types in the DataGrid object. Currently, the new timeseries sources are manually imported but this needs to be changed. 