### PR TITLE
Data Point

### DIFF
--- a/rompy/__init__.py
+++ b/rompy/__init__.py
@@ -11,31 +11,10 @@ from pathlib import Path
 
 # from . import _version
 
-logger = logging.getLogger("rompy")
-
-installed = []
-try:
-    from rompy.core import BaseConfig
-
-    installed.append("base")
-except ImportError:
-    pass
-try:
-    from rompy.swan import SwanConfig
-
-    installed.append("swan")
-except ImportError:
-    pass
-
-try:
-    from rompy.schism import SchismCSIROConfig
-
-    installed.append("schism")
-except ImportError:
-    pass
+logger = logging.getLogger(__name__)
 
 # __version__ = _version.get_versions()["version"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 ROOT_DIR = Path(__file__).parent.resolve()
 TEMPLATES_DIR = ROOT_DIR / "templates"

--- a/rompy/cli.py
+++ b/rompy/cli.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from importlib.metadata import entry_points
 
 import click
 import yaml
-from importlib.metadata import entry_points
-from rompy import installed
 
 from .model import ModelRun
 
 logging.basicConfig(level=logging.INFO)
 
 installed = entry_points(group="rompy.config").names
+
 
 @click.command()
 @click.argument("model", type=click.Choice(installed))

--- a/rompy/cli.py
+++ b/rompy/cli.py
@@ -4,13 +4,14 @@ import logging
 
 import click
 import yaml
-
+from importlib.metadata import entry_points
 from rompy import installed
 
 from .model import ModelRun
 
 logging.basicConfig(level=logging.INFO)
 
+installed = entry_points(group="rompy.config").names
 
 @click.command()
 @click.argument("model", type=click.Choice(installed))

--- a/rompy/core/__init__.py
+++ b/rompy/core/__init__.py
@@ -1,5 +1,5 @@
 from .config import BaseConfig
-from .data import DataBlob, DataGrid
+from .data import DataBlob, DataGrid, DataPoint
 from .filters import *
 from .grid import BaseGrid, RegularGrid
 from .spectrum import LogFrequency

--- a/rompy/core/data.py
+++ b/rompy/core/data.py
@@ -105,7 +105,7 @@ SOURCE_TYPES = load_entry_points("rompy.source")
 SOURCE_TYPES_TS = load_entry_points("rompy.source", etype="timeseries")
 
 
-class DataTimeseries(DataBlob):
+class DataPoint(DataBlob):
     """Data object for timeseries source data.
 
     Generic data object for xarray datasets that only have time as a dimension and do
@@ -113,12 +113,15 @@ class DataTimeseries(DataBlob):
 
     """
 
-    model_type: Literal["timeseries"] = Field(
-        default="timeseries",
+    model_type: Literal["point"] = Field(
+        default="point",
         description="Model type discriminator",
     )
     source: Union[SOURCE_TYPES_TS] = Field(
-        description="Source reader, must return an xarray timeseries dataset in the open method",
+        description=(
+            "Source reader, must return an xarray timeseries point dataset "
+            "in the open method"
+        ),
         discriminator="model_type",
     )
     filter: Optional[Filter] = Field(
@@ -213,7 +216,7 @@ class DataTimeseries(DataBlob):
         return outfile
 
 
-class DataGrid(DataTimeseries):
+class DataGrid(DataPoint):
     """Data object for gridded source data.
 
     Generic data object for xarray datasets that with gridded spatial dimensions

--- a/tests/schism/test_grid.py
+++ b/tests/schism/test_grid.py
@@ -1,10 +1,9 @@
 from pathlib import Path
-
+from importlib.metadata import entry_points
 import pytest
 
 pytest.importorskip("rompy.schism")
 
-from rompy import installed
 from rompy.core import DataBlob
 from rompy.core.grid import BaseGrid
 from rompy.schism import SCHISMGrid
@@ -12,8 +11,9 @@ from rompy.schism.grid import WWMBNDGR3Generator
 
 here = Path(__file__).parent
 
+eps = entry_points(group="rompy.config")
 
-@pytest.mark.skipif("schism" not in installed, reason="requires SCHISM")
+@pytest.mark.skipif("schism" not in eps.names, reason="requires SCHISM")
 def test_SCHISMGrid2D(tmpdir):
     hgrid = DataBlob(source=here / "test_data/hgrid.gr3")
     # drag = DataBlob(source=here / "test_data/drag.gr3")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 from pydantic import ValidationError
 
-from rompy.core import DataBlob, DataGrid, RegularGrid, TimeRange
+from rompy.core import DataBlob, DataGrid, DataPoint, RegularGrid, TimeRange
 from rompy.core.source import (
     SourceDatamesh,
     SourceDataset,
@@ -19,6 +19,7 @@ from rompy.core.source import (
 )
 from rompy.core.filters import Filter
 from rompy.core.types import DatasetCoords
+
 
 HERE = Path(__file__).parent
 DATAMESH_TOKEN = os.environ.get("DATAMESH_TOKEN")
@@ -207,3 +208,11 @@ def test_source_datamesh():
         coords=DatasetCoords(x="longitude", y="latitude"),
     )
     assert isinstance(dset, xr.Dataset)
+
+
+def test_data_point(tmp_path, grid):
+    source = SourceTimeseriesCSV(filename=HERE / "data" / "wind.csv")
+    times = TimeRange(start="2023-01-01", end="2023-01-01T12")
+    data = DataPoint(id="wind", source=source)
+    outfile = data.get(tmp_path, grid, times)
+    assert outfile.is_file()


### PR DESCRIPTION
* Rename the new `DataTimeseries` object into `DataPoint` which is more consistent with DataGrid or DataStation.
* Add tests for DataPoint
* Remove the deprecated `installed` hardcoded list from *\__init__.py*, the list of installed configs can now be dynamically generated from the entrypoints.