### PR TITLE
Traceback

### DIFF
--- a/rompy/core/source.py
+++ b/rompy/core/source.py
@@ -58,7 +58,27 @@ class SourceBase(RompyBaseModel, ABC):
         """
         ds = self._open()
         if variables:
-            ds = ds[variables]
+            try:
+                ds = ds[variables]
+            except KeyError as e:
+                dataset_variables = list(ds.data_vars.keys())
+                missing_variables = list(set(variables) - set(dataset_variables))
+                # raise ValueError(
+                #     f"Attempting to subset variables {variables} from the source "
+                #     f"dataset with variables {dataset_variables}, {missing_variables} "
+                #     "are not available. Are you correctly specifying the variables? "
+                #     "in your data object?"
+                # ) from e
+                raise ValueError(
+                    f"Cannot find requested variables in dataset.\n\n"
+                    f"Requested variables in the Data object: {variables}\n"
+                    f"Available variables in source dataset: {dataset_variables}\n"
+                    f"Missing variables: {missing_variables}\n\n"
+                    f"Please check:\n"
+                    f"1. The variable names in your Data object, make sure you check for default values\n"
+                    f"2. The data source contains the expected variables\n"
+                    f"3. If using a custom data source, ensure it creates variables with the correct names"
+                ) from e
         if filters:
             ds = filters(ds)
         return ds

--- a/rompy/core/source.py
+++ b/rompy/core/source.py
@@ -63,12 +63,6 @@ class SourceBase(RompyBaseModel, ABC):
             except KeyError as e:
                 dataset_variables = list(ds.data_vars.keys())
                 missing_variables = list(set(variables) - set(dataset_variables))
-                # raise ValueError(
-                #     f"Attempting to subset variables {variables} from the source "
-                #     f"dataset with variables {dataset_variables}, {missing_variables} "
-                #     "are not available. Are you correctly specifying the variables? "
-                #     "in your data object?"
-                # ) from e
                 raise ValueError(
                     f"Cannot find requested variables in dataset.\n\n"
                     f"Requested variables in the Data object: {variables}\n"


### PR DESCRIPTION
Raise a ValueError in [rompy.core.source](https://github.com/rom-py/rompy/blob/traceback/rompy/core/source.py#L61-L75) to make it more explicit when requested variables in a Data object are not available in the source dataset.

Example traceback now:

```
ValueError: Cannot find requested variables in dataset.

Requested variables in the Data object: ['dummy']
Available variables in source dataset: ['data']
Missing variables: ['dummy']

Please check:
1. The variable names in your Data object, make sure you check for default values
2. The data source contains the expected variables
3. If using a custom data source, ensure it creates variables with the correct names
```