### PR TITLE
157 move binary data sources to plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,11 @@ schism = "rompy.schism.config:SCHISMConfig"
 schismcsiromigration = "rompy.schism.config:SchismCSIROMigrationConfig"
 
 [project.entry-points."rompy.source"]
-dataset = "rompy.core.source:SourceDataset"
 file = "rompy.core.source:SourceFile"
 intake = "rompy.core.source:SourceIntake"
 datamesh = "rompy.core.source:SourceDatamesh"
 wavespectra = "rompy.core.source:SourceWavespectra"
 "csv:timeseries" = "rompy.core.source:SourceTimeseriesCSV"
-"dataframe:timeseries" = "rompy.core.source:SourceTimeseriesDataFrame"
 
 [project.entry-points."intake.catalogs"]
 "rompy_data" = "rompy:cat"

--- a/rompy/configuration/swan.py
+++ b/rompy/configuration/swan.py
@@ -9,6 +9,6 @@ from pydantic import BaseModel, root_validator, validator
 
 from rompy import TEMPLATES_DIR
 from rompy.configuration.base import BaseConfig
-from rompy.core import RegularGrid
+from rompy.core.grid import RegularGrid
 from rompy.data import DataGrid
 from rompy.types import Coordinate

--- a/rompy/core/__init__.py
+++ b/rompy/core/__init__.py
@@ -1,7 +1,7 @@
-from .config import BaseConfig
-from .data import DataBlob, DataGrid, DataPoint
-from .filters import *
-from .grid import BaseGrid, RegularGrid
-from .spectrum import LogFrequency
-from .time import TimeRange
-from .types import *
+# from .config import BaseConfig
+# from .data import DataBlob, DataGrid, DataPoint
+# from .filters import *
+# from .grid import BaseGrid, RegularGrid
+# from .spectrum import LogFrequency
+# from .time import TimeRange
+# from .types import *

--- a/rompy/core/source.py
+++ b/rompy/core/source.py
@@ -1,6 +1,7 @@
 """Rompy source objects."""
 
 import logging
+import sys
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
@@ -20,6 +21,28 @@ from rompy.core.filters import Filter
 from rompy.core.types import DatasetCoords, RompyBaseModel
 
 logger = logging.getLogger(__name__)
+
+# Import stubs for classes moved to rompy_binary_datasources
+try:
+    from rompy_binary_datasources import SourceDataset, SourceTimeseriesDataFrame
+except ImportError:
+    def _create_import_error_class(class_name):
+        """
+        Create a class that raises a helpful import error when instantiated.
+        """
+        error_message = (
+            f"{class_name} has been moved to the rompy_binary_datasources package.\n"
+            "Please install it using: pip install rompy_binary_datasources"
+        )
+        
+        def __init__(self, *args, **kwargs):
+            raise ImportError(error_message)
+            
+        return type(class_name, (), {"__init__": __init__, "__doc__": error_message})
+    
+    # Create stub classes that will raise a helpful error when instantiated
+    SourceDataset = _create_import_error_class("SourceDataset")
+    SourceTimeseriesDataFrame = _create_import_error_class("SourceTimeseriesDataFrame")
 
 
 class SourceBase(RompyBaseModel, ABC):

--- a/rompy/core/spectrum.py
+++ b/rompy/core/spectrum.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import Field, model_validator
 from pydantic_numpy.typing import Np1DArray
 
-from rompy.core import RompyBaseModel
+from rompy.core.types import RompyBaseModel
 
 
 logger = logging.getLogger(__name__)

--- a/rompy/model.py
+++ b/rompy/model.py
@@ -10,15 +10,19 @@ from typing import Union
 
 from pydantic import Field
 
-from .core import BaseConfig, RompyBaseModel, TimeRange
-from .core.render import render
 from rompy.utils import load_entry_points
+
+from .core.config import BaseConfig
+from .core.render import render
+from .core.time import TimeRange
+from .core.types import RompyBaseModel
 
 logger = logging.getLogger(__name__)
 
 
 # Accepted config types are defined in the entry points of the rompy.config group
 CONFIG_TYPES = load_entry_points("rompy.config")
+
 
 class ModelRun(RompyBaseModel):
     """A model run.

--- a/rompy/schism/data.py
+++ b/rompy/schism/data.py
@@ -9,7 +9,8 @@ import xarray as xr
 from cloudpathlib import AnyPath
 from pydantic import Field, model_validator
 
-from rompy.core import DataGrid, RompyBaseModel
+from rompy.core.data import DataGrid
+from rompy.core.types import RompyBaseModel
 from rompy.core.boundary import BoundaryWaveStation, DataBoundary
 from rompy.core.data import DataBlob
 from rompy.core.time import TimeRange

--- a/rompy/schism/grid.py
+++ b/rompy/schism/grid.py
@@ -7,7 +7,8 @@ import pandas as pd
 from pydantic import Field, PrivateAttr, field_validator, model_validator, model_serializer
 from shapely.geometry import MultiPoint, Polygon
 
-from rompy.core import DataBlob, RompyBaseModel
+from rompy.core.data import DataBlob
+from rompy.core.types import RompyBaseModel
 from rompy.core.grid import BaseGrid
 # from pyschism.mesh import Hgrid
 # from pyschism.mesh.prop import Tvdflag

--- a/rompy/schism/interface.py
+++ b/rompy/schism/interface.py
@@ -11,7 +11,8 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 
-from rompy.core import RompyBaseModel, TimeRange
+from rompy.core.types import RompyBaseModel
+from rompy.core.time import TimeRange
 from rompy.schism.data import SCHISMData
 from rompy.schism.grid import SCHISMGrid
 from rompy.schism.namelists import NML

--- a/rompy/schism/namelists/schism.py
+++ b/rompy/schism/namelists/schism.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import Field, model_serializer
 
-from rompy.core import TimeRange
+from rompy.core.time import TimeRange
 from rompy.schism.namelists.basemodel import NamelistBaseModel
 
 from .cosine import Cosine

--- a/rompy/swan/components/base.py
+++ b/rompy/swan/components/base.py
@@ -13,7 +13,7 @@ from typing import Literal, Optional
 from abc import abstractmethod
 from pydantic import ConfigDict, Field
 
-from rompy.core import RompyBaseModel
+from rompy.core.types import RompyBaseModel
 
 
 logger = logging.getLogger(__name__)

--- a/rompy/swan/config.py
+++ b/rompy/swan/config.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal, Optional, Union
 
 from pydantic import Field, model_validator
 
-from rompy.core import BaseConfig
+from rompy.core.config import BaseConfig
 
 from rompy.swan.interface import (
     DataInterface,

--- a/rompy/swan/data.py
+++ b/rompy/swan/data.py
@@ -8,7 +8,7 @@ import pandas as pd
 import xarray as xr
 from pydantic import field_validator, Field, model_validator
 
-from rompy.core import DataGrid
+from rompy.core.data import DataGrid
 from rompy.core.time import TimeRange
 
 from rompy.swan.grid import SwanGrid

--- a/rompy/swan/interface.py
+++ b/rompy/swan/interface.py
@@ -6,7 +6,8 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 
-from rompy.core import RompyBaseModel, TimeRange
+from rompy.core.types import RompyBaseModel
+from rompy.core.time import TimeRange
 from rompy.swan.boundary import Boundnest1, BoundspecSegmentXY, BoundspecSide
 from rompy.swan.data import SwanDataGrid
 from rompy.swan.grid import SwanGrid

--- a/rompy/swan/legacy.py
+++ b/rompy/swan/legacy.py
@@ -1,15 +1,16 @@
 """Legacy objects in SwanConfig."""
 
 import logging
-from typing import Union, Annotated, Optional, Literal
 from pathlib import Path
+from typing import Annotated, Literal, Optional, Union
+
 from pydantic import Field, field_validator
 
-from rompy.core import RompyBaseModel, TimeRange, Coordinate, Spectrum
-from rompy.swan.grid import SwanGrid
-from rompy.swan.data import SwanDataGrid
+from rompy.core.time import TimeRange
+from rompy.core.types import Coordinate, RompyBaseModel, Spectrum
 from rompy.swan.boundary import Boundnest1
-
+from rompy.swan.data import SwanDataGrid
+from rompy.swan.grid import SwanGrid
 
 logger = logging.getLogger(__name__)
 

--- a/rompy/swan/subcomponents/base.py
+++ b/rompy/swan/subcomponents/base.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 from abc import ABC
 from pydantic import ConfigDict, Field, model_validator
 
-from rompy.core import RompyBaseModel
+from rompy.core.types import RompyBaseModel
 
 
 class BaseSubComponent(RompyBaseModel, ABC):

--- a/tests/schism/test_grid.py
+++ b/tests/schism/test_grid.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("rompy.schism")
 
-from rompy.core import DataBlob
+from rompy.core.data import DataBlob
 from rompy.core.grid import BaseGrid
 from rompy.schism import SCHISMGrid
 from rompy.schism.grid import WWMBNDGR3Generator

--- a/tests/schism/test_schism_csiro.py
+++ b/tests/schism/test_schism_csiro.py
@@ -7,7 +7,8 @@ import pytest
 pytest.importorskip("rompy.schism")
 from utils import compare_files
 
-from rompy.core import DataBlob, TimeRange
+from rompy.core.data import DataBlob
+from rompy.core.time import TimeRange
 from rompy.model import ModelRun
 from rompy.schism import Inputs, SchismCSIROConfig, SCHISMGrid
 

--- a/tests/schism/test_schism_data.py
+++ b/tests/schism/test_schism_data.py
@@ -6,7 +6,8 @@ import pytest
 pytest.importorskip("rompy.schism")
 import xarray as xr
 
-from rompy.core import DataBlob, TimeRange
+from rompy.core.data import DataBlob
+from rompy.core.time import TimeRange
 from rompy.core.source import SourceFile, SourceIntake
 from rompy.schism import SCHISMGrid
 from rompy.schism.data import (

--- a/tests/schism/test_schism_nml.py
+++ b/tests/schism/test_schism_nml.py
@@ -8,7 +8,8 @@ import pytest
 # pytest.importorskip("rompy.schism")
 from utils import compare_files
 
-from rompy.core import DataBlob, TimeRange
+from rompy.core.data import DataBlob
+from rompy.core.time import TimeRange
 from rompy.model import ModelRun
 from rompy.schism import SCHISMConfig, SCHISMGrid
 from rompy.schism.namelists import NML, Param, Wwminput

--- a/tests/schism/test_vgridgenerators.py
+++ b/tests/schism/test_vgridgenerators.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from rompy.core import DataBlob
+from rompy.core.data import DataBlob
 from rompy.schism.grid import Vgrid3D_LSC2, Vgrid3D_SZ, VgridGenerator
 
 HERE = Path(__file__).parent

--- a/tests/test_basegrid.py
+++ b/tests/test_basegrid.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import shapely
 
-from rompy.core import BaseGrid, RegularGrid
+from rompy.core.grid import BaseGrid, RegularGrid
 
 
 class CustomGrid(BaseGrid):

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -1,11 +1,12 @@
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from utils import compare_files
 
+from rompy.core.config import BaseConfig
+from rompy.core.time import TimeRange
 from rompy.model import ModelRun
-from rompy.core import BaseConfig, TimeRange
 
 here = Path(__file__).parent
 

--- a/tests/test_intake_driver.py
+++ b/tests/test_intake_driver.py
@@ -1,9 +1,11 @@
 import os
 from datetime import datetime, timedelta
+
 import pytest
 
 import rompy
-from rompy.core import BaseGrid, DataBlob, DataGrid
+from rompy.core.data import DataBlob, DataGrid
+from rompy.core.grid import BaseGrid
 
 # round now to the nearest 6 hours
 cycle = datetime.utcnow().replace(

--- a/tests/test_serilization.py
+++ b/tests/test_serilization.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from envyaml import EnvYAML
 
-from rompy.core import DataBlob
+from rompy.core.data import DataBlob
 from rompy.core.time import TimeRange
 from rompy.schism.config import SCHISMConfig, SCHISMGrid
 from rompy.schism.namelists import NML, Param, Wwminput

--- a/tests/test_swanbasic.py
+++ b/tests/test_swanbasic.py
@@ -1,11 +1,12 @@
-import pytest
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
+import pytest
 from utils import compare_files
 
+from rompy.core.config import BaseConfig
+from rompy.core.time import TimeRange
 from rompy.model import ModelRun
-from rompy.core import BaseConfig, TimeRange
 
 here = Path(__file__).parent
 

--- a/tests/test_swanboundary.py
+++ b/tests/test_swanboundary.py
@@ -1,14 +1,13 @@
-import pytest
 from pathlib import Path
+
+import pytest
 import xarray as xr
 from wavespectra import read_swan
 
+from rompy.core.source import SourceFile, SourceIntake, SourceWavespectra
 from rompy.core.time import TimeRange
+from rompy.swan.boundary import Boundnest1, BoundspecSegmentXY, BoundspecSide
 from rompy.swan.grid import SwanGrid
-from rompy.core.source import SourceFile, SourceIntake
-from rompy.core.source import SourceWavespectra
-from rompy.swan.boundary import Boundnest1, BoundspecSide, BoundspecSegmentXY
-
 
 HERE = Path(__file__).parent
 

--- a/tests/test_swandata.py
+++ b/tests/test_swandata.py
@@ -3,8 +3,8 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from rompy.core.types import DatasetCoords
 from rompy.core.source import SourceFile
+from rompy.core.types import DatasetCoords
 from rompy.swan.data import SwanDataGrid
 from rompy.swan.grid import SwanGrid
 

--- a/tests/test_swantemplate.py
+++ b/tests/test_swantemplate.py
@@ -1,14 +1,15 @@
 from datetime import datetime
 from pathlib import Path
+
 import numpy as np
 import pytest
 import xarray as xr
 from utils import compare_files
 
-from rompy.model import ModelRun
 from rompy.core.source import SourceFile
-from rompy.core import TimeRange
+from rompy.core.time import TimeRange
 from rompy.core.types import DatasetCoords
+from rompy.model import ModelRun
 from rompy.swan import Boundnest1, SwanConfig, SwanDataGrid, SwanGrid
 
 HERE = Path(__file__).parent

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,11 +1,13 @@
-from pathlib import Path
 from datetime import datetime
-import pytest
+from pathlib import Path
 
+import pytest
 from utils import compare_files
+
 from rompy import TEMPLATES_DIR
+from rompy.core.config import BaseConfig
+from rompy.core.time import TimeRange
 from rompy.model import ModelRun
-from rompy.core import BaseConfig, TimeRange
 
 here = Path(__file__).parent
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from rompy.core import TimeRange
+from rompy.core.time import TimeRange
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request  address #157 . Essentially it moves the dataset and dataframe input types to a separate install. These are removed from the core library here as they fulfil a niche purpose, and being binary inputs, they break the specification. 

The datsources have been moved here:
https://github.com/rom-py/rompy-binary-datasources

These can be installed with:
pip install rompy_binary_datasources

Upon installation, sources are registered as rompy.source using the entrypoint plugin mechanisms. 

Finally, there is some backward compatibility these objects can be imported from the old location if the above package has been installed. If it isn't installed, the user will be prompted to install it when they try and instantiate the imported objects.  We may want to remove that at some point once notebooks etc have been migrated. 